### PR TITLE
chore(deps): daily autoupdate 2026-09-02

### DIFF
--- a/examples/forge-sql-orm-example-ai/static/forge-orm-example/package-lock.json
+++ b/examples/forge-sql-orm-example-ai/static/forge-orm-example/package-lock.json
@@ -8,7 +8,7 @@
       "name": "forge_sql_orm_example_frontend",
       "version": "1.0.0",
       "dependencies": {
-        "@atlaskit/button": "^25.3.0",
+        "@atlaskit/button": "^25.3.1",
         "@atlaskit/css-reset": "^8.4.0",
         "@atlaskit/dynamic-table": "^19.3.1",
         "@atlaskit/primitives": "^22.5.0",
@@ -136,9 +136,9 @@
       }
     },
     "node_modules/@atlaskit/button": {
-      "version": "25.3.0",
-      "resolved": "https://registry.npmjs.org/@atlaskit/button/-/button-25.3.0.tgz",
-      "integrity": "sha512-0bMre5BScC+iOLYCfYc8yJR2BEy+r5kCnZvkdPffhuvPBRKB1TjFY57OaajA98PxPoQbi2F6c3G5sE62zf2rlw==",
+      "version": "25.3.1",
+      "resolved": "https://registry.npmjs.org/@atlaskit/button/-/button-25.3.1.tgz",
+      "integrity": "sha512-6bSO+HcpDRxVw7uT3T5XMaDuqNx/RGWbkRYqWUrTTXVjCLi3UEvfz7oSKC2IR98ig/xNzb2lfGOOYQKqWxvqEA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@atlaskit/analytics-next": "^12.5.0",
@@ -152,7 +152,7 @@
         "@atlaskit/react-compiler-gating": "^0.2.0",
         "@atlaskit/spinner": "^20.4.0",
         "@atlaskit/theme": "^28.2.0",
-        "@atlaskit/tokens": "^16.10.0",
+        "@atlaskit/tokens": "^16.11.0",
         "@atlaskit/tooltip": "^24.3.0",
         "@atlaskit/visually-hidden": "^4.4.0",
         "@babel/runtime": "^7.0.0",

--- a/examples/forge-sql-orm-example-ai/static/forge-orm-example/package.json
+++ b/examples/forge-sql-orm-example-ai/static/forge-orm-example/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "dependencies": {
-    "@atlaskit/button": "^25.3.0",
+    "@atlaskit/button": "^25.3.1",
     "@atlaskit/css-reset": "^8.4.0",
     "@atlaskit/dynamic-table": "^19.3.1",
     "@atlaskit/primitives": "^22.5.0",

--- a/examples/forge-sql-orm-example-atlascamp/package-lock.json
+++ b/examples/forge-sql-orm-example-atlascamp/package-lock.json
@@ -21,7 +21,7 @@
         "@types/node": "^26.4.1",
         "forge-sql-orm-cli": "^2.2.3",
         "knip": "^6.34.0",
-        "mysql2": "^3.24.2",
+        "mysql2": "^3.24.3",
         "typescript": "^6.0.3"
       }
     },
@@ -2714,9 +2714,9 @@
       }
     },
     "node_modules/mysql2": {
-      "version": "3.24.2",
-      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.24.2.tgz",
-      "integrity": "sha512-l9kXeKGwd6VCbSjmpO/bLWb+YCYpbvE4whte8ec6InXebvCNyEEydyRCnRU+TSHNqRLJ8B+Tk1uWb+vMCJgJzA==",
+      "version": "3.24.3",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.24.3.tgz",
+      "integrity": "sha512-OKfWHkMAg9v06neq8FmSyhbxPQKABN9PAW5G9/bDTXzJBO5xXtkKL0V27vju7HQWk9UD4Od5BZsvCtBTB1CPEw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {

--- a/examples/forge-sql-orm-example-atlascamp/package.json
+++ b/examples/forge-sql-orm-example-atlascamp/package.json
@@ -27,7 +27,7 @@
     "@types/node": "^26.4.1",
     "forge-sql-orm-cli": "^2.2.3",
     "knip": "^6.34.0",
-    "mysql2": "^3.24.2",
+    "mysql2": "^3.24.3",
     "typescript": "^6.0.3"
   },
   "overrides": {

--- a/examples/forge-sql-orm-example-backend-ai/static/forge-orm-example/package-lock.json
+++ b/examples/forge-sql-orm-example-backend-ai/static/forge-orm-example/package-lock.json
@@ -8,7 +8,7 @@
       "name": "forge_sql_orm_example_frontend",
       "version": "1.0.0",
       "dependencies": {
-        "@atlaskit/button": "^25.3.0",
+        "@atlaskit/button": "^25.3.1",
         "@atlaskit/css-reset": "^8.4.0",
         "@atlaskit/dynamic-table": "^19.3.1",
         "@atlaskit/primitives": "^22.5.0",
@@ -134,9 +134,9 @@
       }
     },
     "node_modules/@atlaskit/button": {
-      "version": "25.3.0",
-      "resolved": "https://registry.npmjs.org/@atlaskit/button/-/button-25.3.0.tgz",
-      "integrity": "sha512-0bMre5BScC+iOLYCfYc8yJR2BEy+r5kCnZvkdPffhuvPBRKB1TjFY57OaajA98PxPoQbi2F6c3G5sE62zf2rlw==",
+      "version": "25.3.1",
+      "resolved": "https://registry.npmjs.org/@atlaskit/button/-/button-25.3.1.tgz",
+      "integrity": "sha512-6bSO+HcpDRxVw7uT3T5XMaDuqNx/RGWbkRYqWUrTTXVjCLi3UEvfz7oSKC2IR98ig/xNzb2lfGOOYQKqWxvqEA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@atlaskit/analytics-next": "^12.5.0",
@@ -150,7 +150,7 @@
         "@atlaskit/react-compiler-gating": "^0.2.0",
         "@atlaskit/spinner": "^20.4.0",
         "@atlaskit/theme": "^28.2.0",
-        "@atlaskit/tokens": "^16.10.0",
+        "@atlaskit/tokens": "^16.11.0",
         "@atlaskit/tooltip": "^24.3.0",
         "@atlaskit/visually-hidden": "^4.4.0",
         "@babel/runtime": "^7.0.0",

--- a/examples/forge-sql-orm-example-backend-ai/static/forge-orm-example/package.json
+++ b/examples/forge-sql-orm-example-backend-ai/static/forge-orm-example/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "dependencies": {
-    "@atlaskit/button": "^25.3.0",
+    "@atlaskit/button": "^25.3.1",
     "@atlaskit/css-reset": "^8.4.0",
     "@atlaskit/dynamic-table": "^19.3.1",
     "@atlaskit/primitives": "^22.5.0",

--- a/examples/forge-sql-orm-example-cache/package-lock.json
+++ b/examples/forge-sql-orm-example-cache/package-lock.json
@@ -2714,9 +2714,9 @@
       }
     },
     "node_modules/mysql2": {
-      "version": "3.24.2",
-      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.24.2.tgz",
-      "integrity": "sha512-l9kXeKGwd6VCbSjmpO/bLWb+YCYpbvE4whte8ec6InXebvCNyEEydyRCnRU+TSHNqRLJ8B+Tk1uWb+vMCJgJzA==",
+      "version": "3.24.3",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.24.3.tgz",
+      "integrity": "sha512-OKfWHkMAg9v06neq8FmSyhbxPQKABN9PAW5G9/bDTXzJBO5xXtkKL0V27vju7HQWk9UD4Od5BZsvCtBTB1CPEw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {

--- a/examples/forge-sql-orm-example-checklist/package-lock.json
+++ b/examples/forge-sql-orm-example-checklist/package-lock.json
@@ -2668,9 +2668,9 @@
       }
     },
     "node_modules/mysql2": {
-      "version": "3.24.2",
-      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.24.2.tgz",
-      "integrity": "sha512-l9kXeKGwd6VCbSjmpO/bLWb+YCYpbvE4whte8ec6InXebvCNyEEydyRCnRU+TSHNqRLJ8B+Tk1uWb+vMCJgJzA==",
+      "version": "3.24.3",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.24.3.tgz",
+      "integrity": "sha512-OKfWHkMAg9v06neq8FmSyhbxPQKABN9PAW5G9/bDTXzJBO5xXtkKL0V27vju7HQWk9UD4Od5BZsvCtBTB1CPEw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {

--- a/examples/forge-sql-orm-example-drizzle-driver-simple/package-lock.json
+++ b/examples/forge-sql-orm-example-drizzle-driver-simple/package-lock.json
@@ -19,7 +19,7 @@
         "drizzle-kit": "^0.31.10",
         "forge-sql-orm-cli": "^2.2.3",
         "knip": "^6.34.0",
-        "mysql2": "^3.24.2",
+        "mysql2": "^3.24.3",
         "typescript": "^6.0.3"
       }
     },
@@ -2669,9 +2669,9 @@
       }
     },
     "node_modules/mysql2": {
-      "version": "3.24.2",
-      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.24.2.tgz",
-      "integrity": "sha512-l9kXeKGwd6VCbSjmpO/bLWb+YCYpbvE4whte8ec6InXebvCNyEEydyRCnRU+TSHNqRLJ8B+Tk1uWb+vMCJgJzA==",
+      "version": "3.24.3",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.24.3.tgz",
+      "integrity": "sha512-OKfWHkMAg9v06neq8FmSyhbxPQKABN9PAW5G9/bDTXzJBO5xXtkKL0V27vju7HQWk9UD4Od5BZsvCtBTB1CPEw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {

--- a/examples/forge-sql-orm-example-drizzle-driver-simple/package.json
+++ b/examples/forge-sql-orm-example-drizzle-driver-simple/package.json
@@ -14,7 +14,7 @@
     "drizzle-kit": "^0.31.10",
     "forge-sql-orm-cli": "^2.2.3",
     "knip": "^6.34.0",
-    "mysql2": "^3.24.2",
+    "mysql2": "^3.24.3",
     "typescript": "^6.0.3"
   },
   "scripts": {

--- a/examples/forge-sql-orm-example-dynamic/package-lock.json
+++ b/examples/forge-sql-orm-example-dynamic/package-lock.json
@@ -2667,9 +2667,9 @@
       }
     },
     "node_modules/mysql2": {
-      "version": "3.24.2",
-      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.24.2.tgz",
-      "integrity": "sha512-l9kXeKGwd6VCbSjmpO/bLWb+YCYpbvE4whte8ec6InXebvCNyEEydyRCnRU+TSHNqRLJ8B+Tk1uWb+vMCJgJzA==",
+      "version": "3.24.3",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.24.3.tgz",
+      "integrity": "sha512-OKfWHkMAg9v06neq8FmSyhbxPQKABN9PAW5G9/bDTXzJBO5xXtkKL0V27vju7HQWk9UD4Od5BZsvCtBTB1CPEw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {

--- a/examples/forge-sql-orm-example-optimistic-locking/package-lock.json
+++ b/examples/forge-sql-orm-example-optimistic-locking/package-lock.json
@@ -2667,9 +2667,9 @@
       }
     },
     "node_modules/mysql2": {
-      "version": "3.24.2",
-      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.24.2.tgz",
-      "integrity": "sha512-l9kXeKGwd6VCbSjmpO/bLWb+YCYpbvE4whte8ec6InXebvCNyEEydyRCnRU+TSHNqRLJ8B+Tk1uWb+vMCJgJzA==",
+      "version": "3.24.3",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.24.3.tgz",
+      "integrity": "sha512-OKfWHkMAg9v06neq8FmSyhbxPQKABN9PAW5G9/bDTXzJBO5xXtkKL0V27vju7HQWk9UD4Od5BZsvCtBTB1CPEw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {

--- a/examples/forge-sql-orm-example-optimistic-locking/static/forge-orm-example/package-lock.json
+++ b/examples/forge-sql-orm-example-optimistic-locking/static/forge-orm-example/package-lock.json
@@ -8,7 +8,7 @@
       "name": "forge_sql_orm_example_frontend",
       "version": "1.0.0",
       "dependencies": {
-        "@atlaskit/button": "^25.3.0",
+        "@atlaskit/button": "^25.3.1",
         "@atlaskit/css-reset": "^8.4.0",
         "@atlaskit/dynamic-table": "^19.3.1",
         "@atlaskit/tabs": "^21.2.0",
@@ -133,9 +133,9 @@
       }
     },
     "node_modules/@atlaskit/button": {
-      "version": "25.3.0",
-      "resolved": "https://registry.npmjs.org/@atlaskit/button/-/button-25.3.0.tgz",
-      "integrity": "sha512-0bMre5BScC+iOLYCfYc8yJR2BEy+r5kCnZvkdPffhuvPBRKB1TjFY57OaajA98PxPoQbi2F6c3G5sE62zf2rlw==",
+      "version": "25.3.1",
+      "resolved": "https://registry.npmjs.org/@atlaskit/button/-/button-25.3.1.tgz",
+      "integrity": "sha512-6bSO+HcpDRxVw7uT3T5XMaDuqNx/RGWbkRYqWUrTTXVjCLi3UEvfz7oSKC2IR98ig/xNzb2lfGOOYQKqWxvqEA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@atlaskit/analytics-next": "^12.5.0",
@@ -149,7 +149,7 @@
         "@atlaskit/react-compiler-gating": "^0.2.0",
         "@atlaskit/spinner": "^20.4.0",
         "@atlaskit/theme": "^28.2.0",
-        "@atlaskit/tokens": "^16.10.0",
+        "@atlaskit/tokens": "^16.11.0",
         "@atlaskit/tooltip": "^24.3.0",
         "@atlaskit/visually-hidden": "^4.4.0",
         "@babel/runtime": "^7.0.0",

--- a/examples/forge-sql-orm-example-optimistic-locking/static/forge-orm-example/package.json
+++ b/examples/forge-sql-orm-example-optimistic-locking/static/forge-orm-example/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "description": "",
   "dependencies": {
-    "@atlaskit/button": "^25.3.0",
+    "@atlaskit/button": "^25.3.1",
     "@atlaskit/css-reset": "^8.4.0",
     "@atlaskit/dynamic-table": "^19.3.1",
     "@atlaskit/tabs": "^21.2.0",

--- a/examples/forge-sql-orm-example-org-tracker/package-lock.json
+++ b/examples/forge-sql-orm-example-org-tracker/package-lock.json
@@ -2667,9 +2667,9 @@
       }
     },
     "node_modules/mysql2": {
-      "version": "3.24.2",
-      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.24.2.tgz",
-      "integrity": "sha512-l9kXeKGwd6VCbSjmpO/bLWb+YCYpbvE4whte8ec6InXebvCNyEEydyRCnRU+TSHNqRLJ8B+Tk1uWb+vMCJgJzA==",
+      "version": "3.24.3",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.24.3.tgz",
+      "integrity": "sha512-OKfWHkMAg9v06neq8FmSyhbxPQKABN9PAW5G9/bDTXzJBO5xXtkKL0V27vju7HQWk9UD4Od5BZsvCtBTB1CPEw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {

--- a/examples/forge-sql-orm-example-query-analyses/package-lock.json
+++ b/examples/forge-sql-orm-example-query-analyses/package-lock.json
@@ -2668,9 +2668,9 @@
       }
     },
     "node_modules/mysql2": {
-      "version": "3.24.2",
-      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.24.2.tgz",
-      "integrity": "sha512-l9kXeKGwd6VCbSjmpO/bLWb+YCYpbvE4whte8ec6InXebvCNyEEydyRCnRU+TSHNqRLJ8B+Tk1uWb+vMCJgJzA==",
+      "version": "3.24.3",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.24.3.tgz",
+      "integrity": "sha512-OKfWHkMAg9v06neq8FmSyhbxPQKABN9PAW5G9/bDTXzJBO5xXtkKL0V27vju7HQWk9UD4Od5BZsvCtBTB1CPEw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {

--- a/examples/forge-sql-orm-example-simple/package-lock.json
+++ b/examples/forge-sql-orm-example-simple/package-lock.json
@@ -2667,9 +2667,9 @@
       }
     },
     "node_modules/mysql2": {
-      "version": "3.24.2",
-      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.24.2.tgz",
-      "integrity": "sha512-l9kXeKGwd6VCbSjmpO/bLWb+YCYpbvE4whte8ec6InXebvCNyEEydyRCnRU+TSHNqRLJ8B+Tk1uWb+vMCJgJzA==",
+      "version": "3.24.3",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.24.3.tgz",
+      "integrity": "sha512-OKfWHkMAg9v06neq8FmSyhbxPQKABN9PAW5G9/bDTXzJBO5xXtkKL0V27vju7HQWk9UD4Od5BZsvCtBTB1CPEw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {

--- a/examples/forge-sql-orm-example-sql-executor/package-lock.json
+++ b/examples/forge-sql-orm-example-sql-executor/package-lock.json
@@ -2666,9 +2666,9 @@
       }
     },
     "node_modules/mysql2": {
-      "version": "3.24.2",
-      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.24.2.tgz",
-      "integrity": "sha512-l9kXeKGwd6VCbSjmpO/bLWb+YCYpbvE4whte8ec6InXebvCNyEEydyRCnRU+TSHNqRLJ8B+Tk1uWb+vMCJgJzA==",
+      "version": "3.24.3",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.24.3.tgz",
+      "integrity": "sha512-OKfWHkMAg9v06neq8FmSyhbxPQKABN9PAW5G9/bDTXzJBO5xXtkKL0V27vju7HQWk9UD4Od5BZsvCtBTB1CPEw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {

--- a/examples/forge-sql-orm-example-vector/static/forge-orm-example/package-lock.json
+++ b/examples/forge-sql-orm-example-vector/static/forge-orm-example/package-lock.json
@@ -8,7 +8,7 @@
       "name": "forge_sql_orm_example_frontend",
       "version": "1.0.0",
       "dependencies": {
-        "@atlaskit/button": "^25.3.0",
+        "@atlaskit/button": "^25.3.1",
         "@atlaskit/css-reset": "^8.4.0",
         "@atlaskit/primitives": "^22.5.0",
         "@atlaskit/section-message": "^10.2.0",
@@ -132,9 +132,9 @@
       }
     },
     "node_modules/@atlaskit/button": {
-      "version": "25.3.0",
-      "resolved": "https://registry.npmjs.org/@atlaskit/button/-/button-25.3.0.tgz",
-      "integrity": "sha512-0bMre5BScC+iOLYCfYc8yJR2BEy+r5kCnZvkdPffhuvPBRKB1TjFY57OaajA98PxPoQbi2F6c3G5sE62zf2rlw==",
+      "version": "25.3.1",
+      "resolved": "https://registry.npmjs.org/@atlaskit/button/-/button-25.3.1.tgz",
+      "integrity": "sha512-6bSO+HcpDRxVw7uT3T5XMaDuqNx/RGWbkRYqWUrTTXVjCLi3UEvfz7oSKC2IR98ig/xNzb2lfGOOYQKqWxvqEA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@atlaskit/analytics-next": "^12.5.0",
@@ -148,7 +148,7 @@
         "@atlaskit/react-compiler-gating": "^0.2.0",
         "@atlaskit/spinner": "^20.4.0",
         "@atlaskit/theme": "^28.2.0",
-        "@atlaskit/tokens": "^16.10.0",
+        "@atlaskit/tokens": "^16.11.0",
         "@atlaskit/tooltip": "^24.3.0",
         "@atlaskit/visually-hidden": "^4.4.0",
         "@babel/runtime": "^7.0.0",
@@ -637,9 +637,9 @@
       }
     },
     "node_modules/@atlaskit/tokens": {
-      "version": "16.10.0",
-      "resolved": "https://registry.npmjs.org/@atlaskit/tokens/-/tokens-16.10.0.tgz",
-      "integrity": "sha512-N1HzwA50hnKCAqbXC8NTVhWowx1k9vWcETXV9m8jkc4s/JEjFGzpQdeW0KVldtbk8kBMvnqc3tEyxkKF3B6Plg==",
+      "version": "16.11.1",
+      "resolved": "https://registry.npmjs.org/@atlaskit/tokens/-/tokens-16.11.1.tgz",
+      "integrity": "sha512-FvsKDh4ZLdC/5hrCd8X8PU9QlP2BxYiWvAMlC5wB5ilhwPcgOKIS/Cyy5Ff631js3s0eUu+D8XlcUhXusFwduw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@atlaskit/ds-lib": "^8.0.0",

--- a/examples/forge-sql-orm-example-vector/static/forge-orm-example/package.json
+++ b/examples/forge-sql-orm-example-vector/static/forge-orm-example/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "dependencies": {
-    "@atlaskit/button": "^25.3.0",
+    "@atlaskit/button": "^25.3.1",
     "@atlaskit/css-reset": "^8.4.0",
     "@atlaskit/primitives": "^22.5.0",
     "@atlaskit/section-message": "^10.2.0",

--- a/forge-sql-orm-cli/package-lock.json
+++ b/forge-sql-orm-cli/package-lock.json
@@ -15,7 +15,7 @@
         "drizzle-orm": "^0.45.2",
         "forge-sql-orm": "^2.2.3",
         "inquirer": "^14.2.0",
-        "mysql2": "^3.24.2",
+        "mysql2": "^3.24.3",
         "reflect-metadata": "^0.2.2",
         "uuid": "^14.0.2"
       },
@@ -4545,9 +4545,9 @@
       }
     },
     "node_modules/mysql2": {
-      "version": "3.24.2",
-      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.24.2.tgz",
-      "integrity": "sha512-l9kXeKGwd6VCbSjmpO/bLWb+YCYpbvE4whte8ec6InXebvCNyEEydyRCnRU+TSHNqRLJ8B+Tk1uWb+vMCJgJzA==",
+      "version": "3.24.3",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.24.3.tgz",
+      "integrity": "sha512-OKfWHkMAg9v06neq8FmSyhbxPQKABN9PAW5G9/bDTXzJBO5xXtkKL0V27vju7HQWk9UD4Od5BZsvCtBTB1CPEw==",
       "license": "MIT",
       "dependencies": {
         "aws-ssl-profiles": "^1.1.2",

--- a/forge-sql-orm-cli/package.json
+++ b/forge-sql-orm-cli/package.json
@@ -51,7 +51,7 @@
     "drizzle-orm": "^0.45.2",
     "forge-sql-orm": "^2.2.3",
     "inquirer": "^14.2.0",
-    "mysql2": "^3.24.2",
+    "mysql2": "^3.24.3",
     "reflect-metadata": "^0.2.2",
     "uuid": "^14.0.2"
   },


### PR DESCRIPTION
Automated dependency update produced by `.github/workflows/autoupdate.yml`. Will auto-merge once required checks pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the Atlaskit Button package used by several frontend examples to version 25.3.1.
  - Updated the MySQL2 package used by the CLI and database examples to version 3.24.3.
  - These updates keep the examples and command-line tooling aligned with current package releases without changing their documented functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->