### PR TITLE
chore(deps): daily autoupdate 2026-09-03

### DIFF
--- a/examples/forge-sql-orm-example-ai/static/forge-orm-example/package-lock.json
+++ b/examples/forge-sql-orm-example-ai/static/forge-orm-example/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@atlaskit/button": "^25.3.2",
         "@atlaskit/css-reset": "^8.4.0",
-        "@atlaskit/dynamic-table": "^19.3.1",
+        "@atlaskit/dynamic-table": "^19.3.2",
         "@atlaskit/primitives": "^22.5.0",
         "@atlaskit/section-message": "^10.2.0",
         "@atlaskit/spinner": "^20.4.0",
@@ -205,9 +205,9 @@
       }
     },
     "node_modules/@atlaskit/dynamic-table": {
-      "version": "19.3.1",
-      "resolved": "https://registry.npmjs.org/@atlaskit/dynamic-table/-/dynamic-table-19.3.1.tgz",
-      "integrity": "sha512-5XFmU7E3qnYekp/Vqebp1Jo+aPHor5s4ruVRI0nuWp67zW7Efm+S02WA46dy5fHf8fCedMdTWj1pn0ehEXcVwQ==",
+      "version": "19.3.2",
+      "resolved": "https://registry.npmjs.org/@atlaskit/dynamic-table/-/dynamic-table-19.3.2.tgz",
+      "integrity": "sha512-0y5E3pvVGYujJTIFIqaCd1pBnJd7ZUNPsSEvHJKf7CiD46kkDFo5n1F29z0DwIbC1MR6gd0x+XVB28Pxb/R2jw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@atlaskit/analytics-next": "^12.5.0",
@@ -225,8 +225,8 @@
         "@compiled/react": "^1.0.2"
       },
       "peerDependencies": {
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react": "^18.2.0 || ^19.0.0",
+        "react-dom": "^18.2.0 || ^19.0.0"
       }
     },
     "node_modules/@atlaskit/editor-prosemirror": {

--- a/examples/forge-sql-orm-example-ai/static/forge-orm-example/package.json
+++ b/examples/forge-sql-orm-example-ai/static/forge-orm-example/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@atlaskit/button": "^25.3.2",
     "@atlaskit/css-reset": "^8.4.0",
-    "@atlaskit/dynamic-table": "^19.3.1",
+    "@atlaskit/dynamic-table": "^19.3.2",
     "@atlaskit/primitives": "^22.5.0",
     "@atlaskit/section-message": "^10.2.0",
     "@atlaskit/spinner": "^20.4.0",

--- a/examples/forge-sql-orm-example-atlascamp/package-lock.json
+++ b/examples/forge-sql-orm-example-atlascamp/package-lock.json
@@ -692,9 +692,9 @@
       }
     },
     "node_modules/@inquirer/ansi": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.7.tgz",
-      "integrity": "sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.8.tgz",
+      "integrity": "sha512-WpQM+Ti6Z40EFwwt+uL2p4UabT+W179zHp6HhLVOzfbwnVn05IPO/eXIZXGNqcT1jbQ15SujNLzQ39k4QPPxBQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -702,16 +702,16 @@
       }
     },
     "node_modules/@inquirer/checkbox": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.2.3.tgz",
-      "integrity": "sha512-XEYX2WA8SBkLPczL6/yXPHLPCvDoptmh9v56Cy05BSV1Smk1vWy19bTC4qJBuIffw7+6l4CcaYYzGqG60RfW1g==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.2.4.tgz",
+      "integrity": "sha512-oKT5RNeO9oKYizSyOxKb66IrKUsYVMQD2tnjllYW4wmSOe9WawfL3OE2p82JuvAyo+/nDIEem5P4Bm/ZIVYVew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.7",
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/figures": "^2.0.8",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/ansi": "^2.0.8",
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/figures": "^2.0.9",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -726,14 +726,14 @@
       }
     },
     "node_modules/@inquirer/confirm": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.3.0.tgz",
-      "integrity": "sha512-pZHXJImFtERmSNMBHcjwuz8Ck5vEFEYNUZnwbb8aJpjHv/TwGuFErNxF2Hp8+V+pNJs2EYPMlyWscvFEqO9jOQ==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.3.1.tgz",
+      "integrity": "sha512-HvnOHal39DTenOVoRpIy8Z+n4YYfNa3Qhi/P8zFqn9/d1crpmQG0DPx34rwOeOFvotgKr9Vov/14OmKR/Iwfjw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -748,15 +748,15 @@
       }
     },
     "node_modules/@inquirer/core": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-12.0.1.tgz",
-      "integrity": "sha512-JMD5Jy/ScL5TZE18m83Nw25HjqGFLoWXwnEkW7IdwwAhZpB9Bus55/WU7zn3UqR1MOCjjTQOIYpiD4vjWA3LPw==",
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-12.0.2.tgz",
+      "integrity": "sha512-9pBhkxE14uUlnHhs8lOt7qVPtS4caRY6CjADl8COejl9Mf7w8i6Uoe3DrljCqYtmYM3Iv2Q6EmPxx/oTYbvTAQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.7",
-        "@inquirer/figures": "^2.0.8",
-        "@inquirer/type": "^4.1.0",
+        "@inquirer/ansi": "^2.0.8",
+        "@inquirer/figures": "^2.0.9",
+        "@inquirer/type": "4.1.1",
         "cli-width": "^4.1.0",
         "fast-wrap-ansi": "^0.2.0",
         "mute-stream": "^3.0.0",
@@ -775,15 +775,15 @@
       }
     },
     "node_modules/@inquirer/editor": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.3.1.tgz",
-      "integrity": "sha512-y43COoyVUjPWIobn2Qep/uI1drPS78aaZZZ9kVi94Tyu/GuW2N8d8Q4rifJXGAXCEAXCPTTMjD8gC1HyvM5ukA==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.3.2.tgz",
+      "integrity": "sha512-7ruKO5d/wxhGHxdCQ3eyP/aBNrPTZ+Ju7ERtnAwuIsu0RSLs6kotlTRkOxHatbD6sDaEEdwsD82pzFiT9ESIyQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/external-editor": "^3.0.4",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/external-editor": "^3.0.5",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -798,14 +798,14 @@
       }
     },
     "node_modules/@inquirer/expand": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.1.3.tgz",
-      "integrity": "sha512-3NQJiXNJ/aj9wiAsr7pECdp5Qe9J0X9YUJCKsaFXS+ddOxfL6J4AIl3w3T4Gq3kK0WsQY5GMoDokK5X94m6lHw==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.1.4.tgz",
+      "integrity": "sha512-12o4aYnjWouoq0fyVhYIL+hwXAaga+kntA/wrijFmVvn2heinkdvkbEXRt1Ob/9IOJ285US5tntjfI/Ukt2YkA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -820,9 +820,9 @@
       }
     },
     "node_modules/@inquirer/external-editor": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-3.0.4.tgz",
-      "integrity": "sha512-tZbbaK2ovq6vlrRBNQvjrypmrED/p5x2ncIHQ79cD55tei3dD96v5glMMA+6tiq7K104i/25DVYKWVPJuV6ptA==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-3.0.5.tgz",
+      "integrity": "sha512-f3QQJRIX5ZEneBHNUIuPjmbdzHnmRFJA8r2dkcb8q+OM5Uv5KtnuAttQumnrjcBVBM3mcTX1CkmtAkU58VRZxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -859,9 +859,9 @@
       }
     },
     "node_modules/@inquirer/figures": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.8.tgz",
-      "integrity": "sha512-tApbon79GM9ry56ja/Ud3SY2CL4TQsao9fIwDQbgTeNY55025GdMzQ2+UdegV/lx51VNGUB59M0v0nMpybYY4Q==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.9.tgz",
+      "integrity": "sha512-EAWgUTGQ/Umgga51dE3B2PUHbufuXarDfg86uVgoSgNHNNQnyFKcOrQLWVqYMghuSyHh8+2HUH0Js9cTC1WAdg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -869,14 +869,14 @@
       }
     },
     "node_modules/@inquirer/input": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.1.4.tgz",
-      "integrity": "sha512-3xQkQrOvgOzpSN2ciTVdRDlg1FWMCA8l+0KfB6SNlILoTCGzJTzO/gc0Rwjcb3usuGyKdaGtI6OiyMdeMeLWkg==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.1.5.tgz",
+      "integrity": "sha512-2MkYYFD1Owt1eRBwHhsLSutysRodWasA4DVpl42KJKGmzwBTXRYAIXujisrt0UW0UohUlMjNjLfMDbw4emRbfw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -891,14 +891,14 @@
       }
     },
     "node_modules/@inquirer/number": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.2.1.tgz",
-      "integrity": "sha512-5KaqwZNLRpUuWcoCrYghPP9TMaXL5v2Sk4xqePM7RCVegcJStoXdWibio60YIC1bec+z1fCyb67N6XPJIkZtGA==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.2.2.tgz",
+      "integrity": "sha512-tjW1gMIQsFb/9Ie11i8SpuPARBdyCVfC5XOeVugWovrdm8CpjzN+A1CBX5QwCCN2mtNmpgDDCnuLCCT94cQ5zA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -913,15 +913,15 @@
       }
     },
     "node_modules/@inquirer/password": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.2.0.tgz",
-      "integrity": "sha512-CvVcW09emkBESEOW+4R8CjLNkP3fB3XrjeL8CDvfpjgrJN+V9oerXmJAXXM3l+4xqYPD5Yaujzy/Ph0PLOdDuA==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.2.1.tgz",
+      "integrity": "sha512-InA6nJxMCXPavPBiTKYHIsYiWz/mkIsk1rkI6pKp5w18gVawqrZOj7eSzSmPJa3j0pVxXm6RlrFP1BE9YeOixA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.7",
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/ansi": "^2.0.8",
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -936,22 +936,22 @@
       }
     },
     "node_modules/@inquirer/prompts": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.7.0.tgz",
-      "integrity": "sha512-yQwBMYvpJ6jqrXtKiOwRD5XezjJoyt3VQvIyjsr5Arqb519nfIohOQymWVJ8/vEgg8xtZerrCsqlSaqt/LPC9A==",
+      "version": "8.7.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.7.1.tgz",
+      "integrity": "sha512-xJIKWyrFNUKj3R5VEub/iKodG9Sh/MbCeApZUbATJgHTw8YoAJ2gOT78HlvO6NMFiRvjm6ySM7aiAew/zVY0Sw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/checkbox": "^5.2.3",
-        "@inquirer/confirm": "^6.3.0",
-        "@inquirer/editor": "^5.3.1",
-        "@inquirer/expand": "^5.1.3",
-        "@inquirer/input": "^5.1.4",
-        "@inquirer/number": "^4.2.1",
-        "@inquirer/password": "^5.2.0",
-        "@inquirer/rawlist": "^5.3.3",
-        "@inquirer/search": "^4.3.1",
-        "@inquirer/select": "^5.2.3"
+        "@inquirer/checkbox": "^5.2.4",
+        "@inquirer/confirm": "^6.3.1",
+        "@inquirer/editor": "^5.3.2",
+        "@inquirer/expand": "^5.1.4",
+        "@inquirer/input": "^5.1.5",
+        "@inquirer/number": "^4.2.2",
+        "@inquirer/password": "^5.2.1",
+        "@inquirer/rawlist": "^5.3.4",
+        "@inquirer/search": "^4.3.2",
+        "@inquirer/select": "^5.2.4"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -966,14 +966,14 @@
       }
     },
     "node_modules/@inquirer/rawlist": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.3.3.tgz",
-      "integrity": "sha512-Mu7WrtmDLaXBDEyrRLS70SZgX9ZSm4Up1w0ZxiH8C1OOp9oaVCn2k8q3QGgmlnhsKYUhuaU3zFWhAP6wxkVIMA==",
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.3.4.tgz",
+      "integrity": "sha512-c4fDwOpQsjJDHjXdHJE1/xXH6w9/BAiyu3QKzH9Ww5Xm1q37mzyUNa20L7qdtM1ECi4e+oUEKjhK8hR37OMAMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -988,15 +988,15 @@
       }
     },
     "node_modules/@inquirer/search": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.3.1.tgz",
-      "integrity": "sha512-0VWOvsHWI0rPj6CG70MoP4oXNCB6adcyN8bVFZXnh11eLDdPIK2f2XCmva78acPPDfJisfab7qNakwBh7hdBXw==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.3.2.tgz",
+      "integrity": "sha512-YIaEhWmfkdHEWOKwhF/oJar35FFTTrAdzNbJDo9lSsRT6E/obRPx9oVm4rkTMtlcJSqGYttNtLbcHQef9Qw2yw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/figures": "^2.0.8",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/figures": "^2.0.9",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -1011,16 +1011,16 @@
       }
     },
     "node_modules/@inquirer/select": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.2.3.tgz",
-      "integrity": "sha512-KuRTodDa6xBXX2noIpjuitpX/QT7Sfav7dIZ/OfUY54Hxg95nrGoshSzxx6Ey7qqLbImKdiGkSDt7KjPXjQgmA==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.2.4.tgz",
+      "integrity": "sha512-L9ubNaJdoBsiom/AfPKq0QLHTkhhCFCtszzdVidGremrlJjPZfGlmvp+IULKIbnYjtVFWnvb4mhiEdNTZ12ugA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.7",
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/figures": "^2.0.8",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/ansi": "^2.0.8",
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/figures": "^2.0.9",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -1035,9 +1035,9 @@
       }
     },
     "node_modules/@inquirer/type": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.1.0.tgz",
-      "integrity": "sha512-FMiJpuHUG3Dk0ex+UIXkre7i+i4OcwHWk9YdcVtZHFwb/r2rnrU2ipTCNAB7A+QOP0ryzIcqOfy76fRyyvOEAw==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.1.1.tgz",
+      "integrity": "sha512-yJoHYrMnxIsJZCY+0Vb66Dy3he3kL3e2wOBKhoSwWWAzZAY82emlxwgprCtp6yRixvNRNq9ztfRWQYPNr3Go7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2524,16 +2524,16 @@
       }
     },
     "node_modules/inquirer": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-14.2.0.tgz",
-      "integrity": "sha512-OUSQNF7um7AvgPyBiK6ENfjqEG434oeVkRG97U8foLftOfcJfKcTi5pMtagJe5ytANPH5TlbfVgEokAl6RSj6g==",
+      "version": "14.2.1",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-14.2.1.tgz",
+      "integrity": "sha512-jLO8986l0/jW+K2Y5BHAhrD6ztnm8MHQgnTI5BwKV6can/LN6xYBcLbtUSvDt1jXNTASwCZszZk0ZBUT5YmH6Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.7",
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/prompts": "^8.7.0",
-        "@inquirer/type": "^4.1.0",
+        "@inquirer/ansi": "^2.0.8",
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/prompts": "^8.7.1",
+        "@inquirer/type": "4.1.1",
         "mute-stream": "^3.0.0",
         "run-async": "^4.0.6"
       },

--- a/examples/forge-sql-orm-example-backend-ai/static/forge-orm-example/package-lock.json
+++ b/examples/forge-sql-orm-example-backend-ai/static/forge-orm-example/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@atlaskit/button": "^25.3.2",
         "@atlaskit/css-reset": "^8.4.0",
-        "@atlaskit/dynamic-table": "^19.3.1",
+        "@atlaskit/dynamic-table": "^19.3.2",
         "@atlaskit/primitives": "^22.5.0",
         "@atlaskit/section-message": "^10.2.0",
         "@atlaskit/tabs": "^21.2.0",
@@ -203,9 +203,9 @@
       }
     },
     "node_modules/@atlaskit/dynamic-table": {
-      "version": "19.3.1",
-      "resolved": "https://registry.npmjs.org/@atlaskit/dynamic-table/-/dynamic-table-19.3.1.tgz",
-      "integrity": "sha512-5XFmU7E3qnYekp/Vqebp1Jo+aPHor5s4ruVRI0nuWp67zW7Efm+S02WA46dy5fHf8fCedMdTWj1pn0ehEXcVwQ==",
+      "version": "19.3.2",
+      "resolved": "https://registry.npmjs.org/@atlaskit/dynamic-table/-/dynamic-table-19.3.2.tgz",
+      "integrity": "sha512-0y5E3pvVGYujJTIFIqaCd1pBnJd7ZUNPsSEvHJKf7CiD46kkDFo5n1F29z0DwIbC1MR6gd0x+XVB28Pxb/R2jw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@atlaskit/analytics-next": "^12.5.0",
@@ -223,8 +223,8 @@
         "@compiled/react": "^1.0.2"
       },
       "peerDependencies": {
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react": "^18.2.0 || ^19.0.0",
+        "react-dom": "^18.2.0 || ^19.0.0"
       }
     },
     "node_modules/@atlaskit/editor-prosemirror": {

--- a/examples/forge-sql-orm-example-backend-ai/static/forge-orm-example/package.json
+++ b/examples/forge-sql-orm-example-backend-ai/static/forge-orm-example/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@atlaskit/button": "^25.3.2",
     "@atlaskit/css-reset": "^8.4.0",
-    "@atlaskit/dynamic-table": "^19.3.1",
+    "@atlaskit/dynamic-table": "^19.3.2",
     "@atlaskit/primitives": "^22.5.0",
     "@atlaskit/section-message": "^10.2.0",
     "@atlaskit/tabs": "^21.2.0",

--- a/examples/forge-sql-orm-example-cache/package-lock.json
+++ b/examples/forge-sql-orm-example-cache/package-lock.json
@@ -692,9 +692,9 @@
       }
     },
     "node_modules/@inquirer/ansi": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.7.tgz",
-      "integrity": "sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.8.tgz",
+      "integrity": "sha512-WpQM+Ti6Z40EFwwt+uL2p4UabT+W179zHp6HhLVOzfbwnVn05IPO/eXIZXGNqcT1jbQ15SujNLzQ39k4QPPxBQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -702,16 +702,16 @@
       }
     },
     "node_modules/@inquirer/checkbox": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.2.3.tgz",
-      "integrity": "sha512-XEYX2WA8SBkLPczL6/yXPHLPCvDoptmh9v56Cy05BSV1Smk1vWy19bTC4qJBuIffw7+6l4CcaYYzGqG60RfW1g==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.2.4.tgz",
+      "integrity": "sha512-oKT5RNeO9oKYizSyOxKb66IrKUsYVMQD2tnjllYW4wmSOe9WawfL3OE2p82JuvAyo+/nDIEem5P4Bm/ZIVYVew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.7",
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/figures": "^2.0.8",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/ansi": "^2.0.8",
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/figures": "^2.0.9",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -726,14 +726,14 @@
       }
     },
     "node_modules/@inquirer/confirm": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.3.0.tgz",
-      "integrity": "sha512-pZHXJImFtERmSNMBHcjwuz8Ck5vEFEYNUZnwbb8aJpjHv/TwGuFErNxF2Hp8+V+pNJs2EYPMlyWscvFEqO9jOQ==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.3.1.tgz",
+      "integrity": "sha512-HvnOHal39DTenOVoRpIy8Z+n4YYfNa3Qhi/P8zFqn9/d1crpmQG0DPx34rwOeOFvotgKr9Vov/14OmKR/Iwfjw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -748,15 +748,15 @@
       }
     },
     "node_modules/@inquirer/core": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-12.0.1.tgz",
-      "integrity": "sha512-JMD5Jy/ScL5TZE18m83Nw25HjqGFLoWXwnEkW7IdwwAhZpB9Bus55/WU7zn3UqR1MOCjjTQOIYpiD4vjWA3LPw==",
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-12.0.2.tgz",
+      "integrity": "sha512-9pBhkxE14uUlnHhs8lOt7qVPtS4caRY6CjADl8COejl9Mf7w8i6Uoe3DrljCqYtmYM3Iv2Q6EmPxx/oTYbvTAQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.7",
-        "@inquirer/figures": "^2.0.8",
-        "@inquirer/type": "^4.1.0",
+        "@inquirer/ansi": "^2.0.8",
+        "@inquirer/figures": "^2.0.9",
+        "@inquirer/type": "4.1.1",
         "cli-width": "^4.1.0",
         "fast-wrap-ansi": "^0.2.0",
         "mute-stream": "^3.0.0",
@@ -775,15 +775,15 @@
       }
     },
     "node_modules/@inquirer/editor": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.3.1.tgz",
-      "integrity": "sha512-y43COoyVUjPWIobn2Qep/uI1drPS78aaZZZ9kVi94Tyu/GuW2N8d8Q4rifJXGAXCEAXCPTTMjD8gC1HyvM5ukA==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.3.2.tgz",
+      "integrity": "sha512-7ruKO5d/wxhGHxdCQ3eyP/aBNrPTZ+Ju7ERtnAwuIsu0RSLs6kotlTRkOxHatbD6sDaEEdwsD82pzFiT9ESIyQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/external-editor": "^3.0.4",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/external-editor": "^3.0.5",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -798,14 +798,14 @@
       }
     },
     "node_modules/@inquirer/expand": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.1.3.tgz",
-      "integrity": "sha512-3NQJiXNJ/aj9wiAsr7pECdp5Qe9J0X9YUJCKsaFXS+ddOxfL6J4AIl3w3T4Gq3kK0WsQY5GMoDokK5X94m6lHw==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.1.4.tgz",
+      "integrity": "sha512-12o4aYnjWouoq0fyVhYIL+hwXAaga+kntA/wrijFmVvn2heinkdvkbEXRt1Ob/9IOJ285US5tntjfI/Ukt2YkA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -820,9 +820,9 @@
       }
     },
     "node_modules/@inquirer/external-editor": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-3.0.4.tgz",
-      "integrity": "sha512-tZbbaK2ovq6vlrRBNQvjrypmrED/p5x2ncIHQ79cD55tei3dD96v5glMMA+6tiq7K104i/25DVYKWVPJuV6ptA==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-3.0.5.tgz",
+      "integrity": "sha512-f3QQJRIX5ZEneBHNUIuPjmbdzHnmRFJA8r2dkcb8q+OM5Uv5KtnuAttQumnrjcBVBM3mcTX1CkmtAkU58VRZxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -859,9 +859,9 @@
       }
     },
     "node_modules/@inquirer/figures": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.8.tgz",
-      "integrity": "sha512-tApbon79GM9ry56ja/Ud3SY2CL4TQsao9fIwDQbgTeNY55025GdMzQ2+UdegV/lx51VNGUB59M0v0nMpybYY4Q==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.9.tgz",
+      "integrity": "sha512-EAWgUTGQ/Umgga51dE3B2PUHbufuXarDfg86uVgoSgNHNNQnyFKcOrQLWVqYMghuSyHh8+2HUH0Js9cTC1WAdg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -869,14 +869,14 @@
       }
     },
     "node_modules/@inquirer/input": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.1.4.tgz",
-      "integrity": "sha512-3xQkQrOvgOzpSN2ciTVdRDlg1FWMCA8l+0KfB6SNlILoTCGzJTzO/gc0Rwjcb3usuGyKdaGtI6OiyMdeMeLWkg==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.1.5.tgz",
+      "integrity": "sha512-2MkYYFD1Owt1eRBwHhsLSutysRodWasA4DVpl42KJKGmzwBTXRYAIXujisrt0UW0UohUlMjNjLfMDbw4emRbfw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -891,14 +891,14 @@
       }
     },
     "node_modules/@inquirer/number": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.2.1.tgz",
-      "integrity": "sha512-5KaqwZNLRpUuWcoCrYghPP9TMaXL5v2Sk4xqePM7RCVegcJStoXdWibio60YIC1bec+z1fCyb67N6XPJIkZtGA==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.2.2.tgz",
+      "integrity": "sha512-tjW1gMIQsFb/9Ie11i8SpuPARBdyCVfC5XOeVugWovrdm8CpjzN+A1CBX5QwCCN2mtNmpgDDCnuLCCT94cQ5zA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -913,15 +913,15 @@
       }
     },
     "node_modules/@inquirer/password": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.2.0.tgz",
-      "integrity": "sha512-CvVcW09emkBESEOW+4R8CjLNkP3fB3XrjeL8CDvfpjgrJN+V9oerXmJAXXM3l+4xqYPD5Yaujzy/Ph0PLOdDuA==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.2.1.tgz",
+      "integrity": "sha512-InA6nJxMCXPavPBiTKYHIsYiWz/mkIsk1rkI6pKp5w18gVawqrZOj7eSzSmPJa3j0pVxXm6RlrFP1BE9YeOixA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.7",
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/ansi": "^2.0.8",
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -936,22 +936,22 @@
       }
     },
     "node_modules/@inquirer/prompts": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.7.0.tgz",
-      "integrity": "sha512-yQwBMYvpJ6jqrXtKiOwRD5XezjJoyt3VQvIyjsr5Arqb519nfIohOQymWVJ8/vEgg8xtZerrCsqlSaqt/LPC9A==",
+      "version": "8.7.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.7.1.tgz",
+      "integrity": "sha512-xJIKWyrFNUKj3R5VEub/iKodG9Sh/MbCeApZUbATJgHTw8YoAJ2gOT78HlvO6NMFiRvjm6ySM7aiAew/zVY0Sw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/checkbox": "^5.2.3",
-        "@inquirer/confirm": "^6.3.0",
-        "@inquirer/editor": "^5.3.1",
-        "@inquirer/expand": "^5.1.3",
-        "@inquirer/input": "^5.1.4",
-        "@inquirer/number": "^4.2.1",
-        "@inquirer/password": "^5.2.0",
-        "@inquirer/rawlist": "^5.3.3",
-        "@inquirer/search": "^4.3.1",
-        "@inquirer/select": "^5.2.3"
+        "@inquirer/checkbox": "^5.2.4",
+        "@inquirer/confirm": "^6.3.1",
+        "@inquirer/editor": "^5.3.2",
+        "@inquirer/expand": "^5.1.4",
+        "@inquirer/input": "^5.1.5",
+        "@inquirer/number": "^4.2.2",
+        "@inquirer/password": "^5.2.1",
+        "@inquirer/rawlist": "^5.3.4",
+        "@inquirer/search": "^4.3.2",
+        "@inquirer/select": "^5.2.4"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -966,14 +966,14 @@
       }
     },
     "node_modules/@inquirer/rawlist": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.3.3.tgz",
-      "integrity": "sha512-Mu7WrtmDLaXBDEyrRLS70SZgX9ZSm4Up1w0ZxiH8C1OOp9oaVCn2k8q3QGgmlnhsKYUhuaU3zFWhAP6wxkVIMA==",
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.3.4.tgz",
+      "integrity": "sha512-c4fDwOpQsjJDHjXdHJE1/xXH6w9/BAiyu3QKzH9Ww5Xm1q37mzyUNa20L7qdtM1ECi4e+oUEKjhK8hR37OMAMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -988,15 +988,15 @@
       }
     },
     "node_modules/@inquirer/search": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.3.1.tgz",
-      "integrity": "sha512-0VWOvsHWI0rPj6CG70MoP4oXNCB6adcyN8bVFZXnh11eLDdPIK2f2XCmva78acPPDfJisfab7qNakwBh7hdBXw==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.3.2.tgz",
+      "integrity": "sha512-YIaEhWmfkdHEWOKwhF/oJar35FFTTrAdzNbJDo9lSsRT6E/obRPx9oVm4rkTMtlcJSqGYttNtLbcHQef9Qw2yw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/figures": "^2.0.8",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/figures": "^2.0.9",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -1011,16 +1011,16 @@
       }
     },
     "node_modules/@inquirer/select": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.2.3.tgz",
-      "integrity": "sha512-KuRTodDa6xBXX2noIpjuitpX/QT7Sfav7dIZ/OfUY54Hxg95nrGoshSzxx6Ey7qqLbImKdiGkSDt7KjPXjQgmA==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.2.4.tgz",
+      "integrity": "sha512-L9ubNaJdoBsiom/AfPKq0QLHTkhhCFCtszzdVidGremrlJjPZfGlmvp+IULKIbnYjtVFWnvb4mhiEdNTZ12ugA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.7",
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/figures": "^2.0.8",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/ansi": "^2.0.8",
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/figures": "^2.0.9",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -1035,9 +1035,9 @@
       }
     },
     "node_modules/@inquirer/type": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.1.0.tgz",
-      "integrity": "sha512-FMiJpuHUG3Dk0ex+UIXkre7i+i4OcwHWk9YdcVtZHFwb/r2rnrU2ipTCNAB7A+QOP0ryzIcqOfy76fRyyvOEAw==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.1.1.tgz",
+      "integrity": "sha512-yJoHYrMnxIsJZCY+0Vb66Dy3he3kL3e2wOBKhoSwWWAzZAY82emlxwgprCtp6yRixvNRNq9ztfRWQYPNr3Go7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2524,16 +2524,16 @@
       }
     },
     "node_modules/inquirer": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-14.2.0.tgz",
-      "integrity": "sha512-OUSQNF7um7AvgPyBiK6ENfjqEG434oeVkRG97U8foLftOfcJfKcTi5pMtagJe5ytANPH5TlbfVgEokAl6RSj6g==",
+      "version": "14.2.1",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-14.2.1.tgz",
+      "integrity": "sha512-jLO8986l0/jW+K2Y5BHAhrD6ztnm8MHQgnTI5BwKV6can/LN6xYBcLbtUSvDt1jXNTASwCZszZk0ZBUT5YmH6Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.7",
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/prompts": "^8.7.0",
-        "@inquirer/type": "^4.1.0",
+        "@inquirer/ansi": "^2.0.8",
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/prompts": "^8.7.1",
+        "@inquirer/type": "4.1.1",
         "mute-stream": "^3.0.0",
         "run-async": "^4.0.6"
       },

--- a/examples/forge-sql-orm-example-checklist/package-lock.json
+++ b/examples/forge-sql-orm-example-checklist/package-lock.json
@@ -673,9 +673,9 @@
       }
     },
     "node_modules/@inquirer/ansi": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.7.tgz",
-      "integrity": "sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.8.tgz",
+      "integrity": "sha512-WpQM+Ti6Z40EFwwt+uL2p4UabT+W179zHp6HhLVOzfbwnVn05IPO/eXIZXGNqcT1jbQ15SujNLzQ39k4QPPxBQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -683,16 +683,16 @@
       }
     },
     "node_modules/@inquirer/checkbox": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.2.3.tgz",
-      "integrity": "sha512-XEYX2WA8SBkLPczL6/yXPHLPCvDoptmh9v56Cy05BSV1Smk1vWy19bTC4qJBuIffw7+6l4CcaYYzGqG60RfW1g==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.2.4.tgz",
+      "integrity": "sha512-oKT5RNeO9oKYizSyOxKb66IrKUsYVMQD2tnjllYW4wmSOe9WawfL3OE2p82JuvAyo+/nDIEem5P4Bm/ZIVYVew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.7",
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/figures": "^2.0.8",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/ansi": "^2.0.8",
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/figures": "^2.0.9",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -707,14 +707,14 @@
       }
     },
     "node_modules/@inquirer/confirm": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.3.0.tgz",
-      "integrity": "sha512-pZHXJImFtERmSNMBHcjwuz8Ck5vEFEYNUZnwbb8aJpjHv/TwGuFErNxF2Hp8+V+pNJs2EYPMlyWscvFEqO9jOQ==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.3.1.tgz",
+      "integrity": "sha512-HvnOHal39DTenOVoRpIy8Z+n4YYfNa3Qhi/P8zFqn9/d1crpmQG0DPx34rwOeOFvotgKr9Vov/14OmKR/Iwfjw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -729,15 +729,15 @@
       }
     },
     "node_modules/@inquirer/core": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-12.0.1.tgz",
-      "integrity": "sha512-JMD5Jy/ScL5TZE18m83Nw25HjqGFLoWXwnEkW7IdwwAhZpB9Bus55/WU7zn3UqR1MOCjjTQOIYpiD4vjWA3LPw==",
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-12.0.2.tgz",
+      "integrity": "sha512-9pBhkxE14uUlnHhs8lOt7qVPtS4caRY6CjADl8COejl9Mf7w8i6Uoe3DrljCqYtmYM3Iv2Q6EmPxx/oTYbvTAQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.7",
-        "@inquirer/figures": "^2.0.8",
-        "@inquirer/type": "^4.1.0",
+        "@inquirer/ansi": "^2.0.8",
+        "@inquirer/figures": "^2.0.9",
+        "@inquirer/type": "4.1.1",
         "cli-width": "^4.1.0",
         "fast-wrap-ansi": "^0.2.0",
         "mute-stream": "^3.0.0",
@@ -756,15 +756,15 @@
       }
     },
     "node_modules/@inquirer/editor": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.3.1.tgz",
-      "integrity": "sha512-y43COoyVUjPWIobn2Qep/uI1drPS78aaZZZ9kVi94Tyu/GuW2N8d8Q4rifJXGAXCEAXCPTTMjD8gC1HyvM5ukA==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.3.2.tgz",
+      "integrity": "sha512-7ruKO5d/wxhGHxdCQ3eyP/aBNrPTZ+Ju7ERtnAwuIsu0RSLs6kotlTRkOxHatbD6sDaEEdwsD82pzFiT9ESIyQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/external-editor": "^3.0.4",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/external-editor": "^3.0.5",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -779,14 +779,14 @@
       }
     },
     "node_modules/@inquirer/expand": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.1.3.tgz",
-      "integrity": "sha512-3NQJiXNJ/aj9wiAsr7pECdp5Qe9J0X9YUJCKsaFXS+ddOxfL6J4AIl3w3T4Gq3kK0WsQY5GMoDokK5X94m6lHw==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.1.4.tgz",
+      "integrity": "sha512-12o4aYnjWouoq0fyVhYIL+hwXAaga+kntA/wrijFmVvn2heinkdvkbEXRt1Ob/9IOJ285US5tntjfI/Ukt2YkA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -801,9 +801,9 @@
       }
     },
     "node_modules/@inquirer/external-editor": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-3.0.4.tgz",
-      "integrity": "sha512-tZbbaK2ovq6vlrRBNQvjrypmrED/p5x2ncIHQ79cD55tei3dD96v5glMMA+6tiq7K104i/25DVYKWVPJuV6ptA==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-3.0.5.tgz",
+      "integrity": "sha512-f3QQJRIX5ZEneBHNUIuPjmbdzHnmRFJA8r2dkcb8q+OM5Uv5KtnuAttQumnrjcBVBM3mcTX1CkmtAkU58VRZxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -840,9 +840,9 @@
       }
     },
     "node_modules/@inquirer/figures": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.8.tgz",
-      "integrity": "sha512-tApbon79GM9ry56ja/Ud3SY2CL4TQsao9fIwDQbgTeNY55025GdMzQ2+UdegV/lx51VNGUB59M0v0nMpybYY4Q==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.9.tgz",
+      "integrity": "sha512-EAWgUTGQ/Umgga51dE3B2PUHbufuXarDfg86uVgoSgNHNNQnyFKcOrQLWVqYMghuSyHh8+2HUH0Js9cTC1WAdg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -850,14 +850,14 @@
       }
     },
     "node_modules/@inquirer/input": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.1.4.tgz",
-      "integrity": "sha512-3xQkQrOvgOzpSN2ciTVdRDlg1FWMCA8l+0KfB6SNlILoTCGzJTzO/gc0Rwjcb3usuGyKdaGtI6OiyMdeMeLWkg==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.1.5.tgz",
+      "integrity": "sha512-2MkYYFD1Owt1eRBwHhsLSutysRodWasA4DVpl42KJKGmzwBTXRYAIXujisrt0UW0UohUlMjNjLfMDbw4emRbfw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -872,14 +872,14 @@
       }
     },
     "node_modules/@inquirer/number": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.2.1.tgz",
-      "integrity": "sha512-5KaqwZNLRpUuWcoCrYghPP9TMaXL5v2Sk4xqePM7RCVegcJStoXdWibio60YIC1bec+z1fCyb67N6XPJIkZtGA==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.2.2.tgz",
+      "integrity": "sha512-tjW1gMIQsFb/9Ie11i8SpuPARBdyCVfC5XOeVugWovrdm8CpjzN+A1CBX5QwCCN2mtNmpgDDCnuLCCT94cQ5zA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -894,15 +894,15 @@
       }
     },
     "node_modules/@inquirer/password": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.2.0.tgz",
-      "integrity": "sha512-CvVcW09emkBESEOW+4R8CjLNkP3fB3XrjeL8CDvfpjgrJN+V9oerXmJAXXM3l+4xqYPD5Yaujzy/Ph0PLOdDuA==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.2.1.tgz",
+      "integrity": "sha512-InA6nJxMCXPavPBiTKYHIsYiWz/mkIsk1rkI6pKp5w18gVawqrZOj7eSzSmPJa3j0pVxXm6RlrFP1BE9YeOixA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.7",
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/ansi": "^2.0.8",
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -917,22 +917,22 @@
       }
     },
     "node_modules/@inquirer/prompts": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.7.0.tgz",
-      "integrity": "sha512-yQwBMYvpJ6jqrXtKiOwRD5XezjJoyt3VQvIyjsr5Arqb519nfIohOQymWVJ8/vEgg8xtZerrCsqlSaqt/LPC9A==",
+      "version": "8.7.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.7.1.tgz",
+      "integrity": "sha512-xJIKWyrFNUKj3R5VEub/iKodG9Sh/MbCeApZUbATJgHTw8YoAJ2gOT78HlvO6NMFiRvjm6ySM7aiAew/zVY0Sw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/checkbox": "^5.2.3",
-        "@inquirer/confirm": "^6.3.0",
-        "@inquirer/editor": "^5.3.1",
-        "@inquirer/expand": "^5.1.3",
-        "@inquirer/input": "^5.1.4",
-        "@inquirer/number": "^4.2.1",
-        "@inquirer/password": "^5.2.0",
-        "@inquirer/rawlist": "^5.3.3",
-        "@inquirer/search": "^4.3.1",
-        "@inquirer/select": "^5.2.3"
+        "@inquirer/checkbox": "^5.2.4",
+        "@inquirer/confirm": "^6.3.1",
+        "@inquirer/editor": "^5.3.2",
+        "@inquirer/expand": "^5.1.4",
+        "@inquirer/input": "^5.1.5",
+        "@inquirer/number": "^4.2.2",
+        "@inquirer/password": "^5.2.1",
+        "@inquirer/rawlist": "^5.3.4",
+        "@inquirer/search": "^4.3.2",
+        "@inquirer/select": "^5.2.4"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -947,14 +947,14 @@
       }
     },
     "node_modules/@inquirer/rawlist": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.3.3.tgz",
-      "integrity": "sha512-Mu7WrtmDLaXBDEyrRLS70SZgX9ZSm4Up1w0ZxiH8C1OOp9oaVCn2k8q3QGgmlnhsKYUhuaU3zFWhAP6wxkVIMA==",
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.3.4.tgz",
+      "integrity": "sha512-c4fDwOpQsjJDHjXdHJE1/xXH6w9/BAiyu3QKzH9Ww5Xm1q37mzyUNa20L7qdtM1ECi4e+oUEKjhK8hR37OMAMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -969,15 +969,15 @@
       }
     },
     "node_modules/@inquirer/search": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.3.1.tgz",
-      "integrity": "sha512-0VWOvsHWI0rPj6CG70MoP4oXNCB6adcyN8bVFZXnh11eLDdPIK2f2XCmva78acPPDfJisfab7qNakwBh7hdBXw==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.3.2.tgz",
+      "integrity": "sha512-YIaEhWmfkdHEWOKwhF/oJar35FFTTrAdzNbJDo9lSsRT6E/obRPx9oVm4rkTMtlcJSqGYttNtLbcHQef9Qw2yw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/figures": "^2.0.8",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/figures": "^2.0.9",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -992,16 +992,16 @@
       }
     },
     "node_modules/@inquirer/select": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.2.3.tgz",
-      "integrity": "sha512-KuRTodDa6xBXX2noIpjuitpX/QT7Sfav7dIZ/OfUY54Hxg95nrGoshSzxx6Ey7qqLbImKdiGkSDt7KjPXjQgmA==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.2.4.tgz",
+      "integrity": "sha512-L9ubNaJdoBsiom/AfPKq0QLHTkhhCFCtszzdVidGremrlJjPZfGlmvp+IULKIbnYjtVFWnvb4mhiEdNTZ12ugA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.7",
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/figures": "^2.0.8",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/ansi": "^2.0.8",
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/figures": "^2.0.9",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -1016,9 +1016,9 @@
       }
     },
     "node_modules/@inquirer/type": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.1.0.tgz",
-      "integrity": "sha512-FMiJpuHUG3Dk0ex+UIXkre7i+i4OcwHWk9YdcVtZHFwb/r2rnrU2ipTCNAB7A+QOP0ryzIcqOfy76fRyyvOEAw==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.1.1.tgz",
+      "integrity": "sha512-yJoHYrMnxIsJZCY+0Vb66Dy3he3kL3e2wOBKhoSwWWAzZAY82emlxwgprCtp6yRixvNRNq9ztfRWQYPNr3Go7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2478,16 +2478,16 @@
       }
     },
     "node_modules/inquirer": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-14.2.0.tgz",
-      "integrity": "sha512-OUSQNF7um7AvgPyBiK6ENfjqEG434oeVkRG97U8foLftOfcJfKcTi5pMtagJe5ytANPH5TlbfVgEokAl6RSj6g==",
+      "version": "14.2.1",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-14.2.1.tgz",
+      "integrity": "sha512-jLO8986l0/jW+K2Y5BHAhrD6ztnm8MHQgnTI5BwKV6can/LN6xYBcLbtUSvDt1jXNTASwCZszZk0ZBUT5YmH6Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.7",
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/prompts": "^8.7.0",
-        "@inquirer/type": "^4.1.0",
+        "@inquirer/ansi": "^2.0.8",
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/prompts": "^8.7.1",
+        "@inquirer/type": "4.1.1",
         "mute-stream": "^3.0.0",
         "run-async": "^4.0.6"
       },

--- a/examples/forge-sql-orm-example-drizzle-driver-simple/package-lock.json
+++ b/examples/forge-sql-orm-example-drizzle-driver-simple/package-lock.json
@@ -674,9 +674,9 @@
       }
     },
     "node_modules/@inquirer/ansi": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.7.tgz",
-      "integrity": "sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.8.tgz",
+      "integrity": "sha512-WpQM+Ti6Z40EFwwt+uL2p4UabT+W179zHp6HhLVOzfbwnVn05IPO/eXIZXGNqcT1jbQ15SujNLzQ39k4QPPxBQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -684,16 +684,16 @@
       }
     },
     "node_modules/@inquirer/checkbox": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.2.3.tgz",
-      "integrity": "sha512-XEYX2WA8SBkLPczL6/yXPHLPCvDoptmh9v56Cy05BSV1Smk1vWy19bTC4qJBuIffw7+6l4CcaYYzGqG60RfW1g==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.2.4.tgz",
+      "integrity": "sha512-oKT5RNeO9oKYizSyOxKb66IrKUsYVMQD2tnjllYW4wmSOe9WawfL3OE2p82JuvAyo+/nDIEem5P4Bm/ZIVYVew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.7",
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/figures": "^2.0.8",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/ansi": "^2.0.8",
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/figures": "^2.0.9",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -708,14 +708,14 @@
       }
     },
     "node_modules/@inquirer/confirm": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.3.0.tgz",
-      "integrity": "sha512-pZHXJImFtERmSNMBHcjwuz8Ck5vEFEYNUZnwbb8aJpjHv/TwGuFErNxF2Hp8+V+pNJs2EYPMlyWscvFEqO9jOQ==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.3.1.tgz",
+      "integrity": "sha512-HvnOHal39DTenOVoRpIy8Z+n4YYfNa3Qhi/P8zFqn9/d1crpmQG0DPx34rwOeOFvotgKr9Vov/14OmKR/Iwfjw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -730,15 +730,15 @@
       }
     },
     "node_modules/@inquirer/core": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-12.0.1.tgz",
-      "integrity": "sha512-JMD5Jy/ScL5TZE18m83Nw25HjqGFLoWXwnEkW7IdwwAhZpB9Bus55/WU7zn3UqR1MOCjjTQOIYpiD4vjWA3LPw==",
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-12.0.2.tgz",
+      "integrity": "sha512-9pBhkxE14uUlnHhs8lOt7qVPtS4caRY6CjADl8COejl9Mf7w8i6Uoe3DrljCqYtmYM3Iv2Q6EmPxx/oTYbvTAQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.7",
-        "@inquirer/figures": "^2.0.8",
-        "@inquirer/type": "^4.1.0",
+        "@inquirer/ansi": "^2.0.8",
+        "@inquirer/figures": "^2.0.9",
+        "@inquirer/type": "4.1.1",
         "cli-width": "^4.1.0",
         "fast-wrap-ansi": "^0.2.0",
         "mute-stream": "^3.0.0",
@@ -757,15 +757,15 @@
       }
     },
     "node_modules/@inquirer/editor": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.3.1.tgz",
-      "integrity": "sha512-y43COoyVUjPWIobn2Qep/uI1drPS78aaZZZ9kVi94Tyu/GuW2N8d8Q4rifJXGAXCEAXCPTTMjD8gC1HyvM5ukA==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.3.2.tgz",
+      "integrity": "sha512-7ruKO5d/wxhGHxdCQ3eyP/aBNrPTZ+Ju7ERtnAwuIsu0RSLs6kotlTRkOxHatbD6sDaEEdwsD82pzFiT9ESIyQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/external-editor": "^3.0.4",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/external-editor": "^3.0.5",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -780,14 +780,14 @@
       }
     },
     "node_modules/@inquirer/expand": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.1.3.tgz",
-      "integrity": "sha512-3NQJiXNJ/aj9wiAsr7pECdp5Qe9J0X9YUJCKsaFXS+ddOxfL6J4AIl3w3T4Gq3kK0WsQY5GMoDokK5X94m6lHw==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.1.4.tgz",
+      "integrity": "sha512-12o4aYnjWouoq0fyVhYIL+hwXAaga+kntA/wrijFmVvn2heinkdvkbEXRt1Ob/9IOJ285US5tntjfI/Ukt2YkA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -802,9 +802,9 @@
       }
     },
     "node_modules/@inquirer/external-editor": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-3.0.4.tgz",
-      "integrity": "sha512-tZbbaK2ovq6vlrRBNQvjrypmrED/p5x2ncIHQ79cD55tei3dD96v5glMMA+6tiq7K104i/25DVYKWVPJuV6ptA==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-3.0.5.tgz",
+      "integrity": "sha512-f3QQJRIX5ZEneBHNUIuPjmbdzHnmRFJA8r2dkcb8q+OM5Uv5KtnuAttQumnrjcBVBM3mcTX1CkmtAkU58VRZxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -841,9 +841,9 @@
       }
     },
     "node_modules/@inquirer/figures": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.8.tgz",
-      "integrity": "sha512-tApbon79GM9ry56ja/Ud3SY2CL4TQsao9fIwDQbgTeNY55025GdMzQ2+UdegV/lx51VNGUB59M0v0nMpybYY4Q==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.9.tgz",
+      "integrity": "sha512-EAWgUTGQ/Umgga51dE3B2PUHbufuXarDfg86uVgoSgNHNNQnyFKcOrQLWVqYMghuSyHh8+2HUH0Js9cTC1WAdg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -851,14 +851,14 @@
       }
     },
     "node_modules/@inquirer/input": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.1.4.tgz",
-      "integrity": "sha512-3xQkQrOvgOzpSN2ciTVdRDlg1FWMCA8l+0KfB6SNlILoTCGzJTzO/gc0Rwjcb3usuGyKdaGtI6OiyMdeMeLWkg==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.1.5.tgz",
+      "integrity": "sha512-2MkYYFD1Owt1eRBwHhsLSutysRodWasA4DVpl42KJKGmzwBTXRYAIXujisrt0UW0UohUlMjNjLfMDbw4emRbfw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -873,14 +873,14 @@
       }
     },
     "node_modules/@inquirer/number": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.2.1.tgz",
-      "integrity": "sha512-5KaqwZNLRpUuWcoCrYghPP9TMaXL5v2Sk4xqePM7RCVegcJStoXdWibio60YIC1bec+z1fCyb67N6XPJIkZtGA==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.2.2.tgz",
+      "integrity": "sha512-tjW1gMIQsFb/9Ie11i8SpuPARBdyCVfC5XOeVugWovrdm8CpjzN+A1CBX5QwCCN2mtNmpgDDCnuLCCT94cQ5zA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -895,15 +895,15 @@
       }
     },
     "node_modules/@inquirer/password": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.2.0.tgz",
-      "integrity": "sha512-CvVcW09emkBESEOW+4R8CjLNkP3fB3XrjeL8CDvfpjgrJN+V9oerXmJAXXM3l+4xqYPD5Yaujzy/Ph0PLOdDuA==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.2.1.tgz",
+      "integrity": "sha512-InA6nJxMCXPavPBiTKYHIsYiWz/mkIsk1rkI6pKp5w18gVawqrZOj7eSzSmPJa3j0pVxXm6RlrFP1BE9YeOixA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.7",
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/ansi": "^2.0.8",
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -918,22 +918,22 @@
       }
     },
     "node_modules/@inquirer/prompts": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.7.0.tgz",
-      "integrity": "sha512-yQwBMYvpJ6jqrXtKiOwRD5XezjJoyt3VQvIyjsr5Arqb519nfIohOQymWVJ8/vEgg8xtZerrCsqlSaqt/LPC9A==",
+      "version": "8.7.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.7.1.tgz",
+      "integrity": "sha512-xJIKWyrFNUKj3R5VEub/iKodG9Sh/MbCeApZUbATJgHTw8YoAJ2gOT78HlvO6NMFiRvjm6ySM7aiAew/zVY0Sw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/checkbox": "^5.2.3",
-        "@inquirer/confirm": "^6.3.0",
-        "@inquirer/editor": "^5.3.1",
-        "@inquirer/expand": "^5.1.3",
-        "@inquirer/input": "^5.1.4",
-        "@inquirer/number": "^4.2.1",
-        "@inquirer/password": "^5.2.0",
-        "@inquirer/rawlist": "^5.3.3",
-        "@inquirer/search": "^4.3.1",
-        "@inquirer/select": "^5.2.3"
+        "@inquirer/checkbox": "^5.2.4",
+        "@inquirer/confirm": "^6.3.1",
+        "@inquirer/editor": "^5.3.2",
+        "@inquirer/expand": "^5.1.4",
+        "@inquirer/input": "^5.1.5",
+        "@inquirer/number": "^4.2.2",
+        "@inquirer/password": "^5.2.1",
+        "@inquirer/rawlist": "^5.3.4",
+        "@inquirer/search": "^4.3.2",
+        "@inquirer/select": "^5.2.4"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -948,14 +948,14 @@
       }
     },
     "node_modules/@inquirer/rawlist": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.3.3.tgz",
-      "integrity": "sha512-Mu7WrtmDLaXBDEyrRLS70SZgX9ZSm4Up1w0ZxiH8C1OOp9oaVCn2k8q3QGgmlnhsKYUhuaU3zFWhAP6wxkVIMA==",
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.3.4.tgz",
+      "integrity": "sha512-c4fDwOpQsjJDHjXdHJE1/xXH6w9/BAiyu3QKzH9Ww5Xm1q37mzyUNa20L7qdtM1ECi4e+oUEKjhK8hR37OMAMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -970,15 +970,15 @@
       }
     },
     "node_modules/@inquirer/search": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.3.1.tgz",
-      "integrity": "sha512-0VWOvsHWI0rPj6CG70MoP4oXNCB6adcyN8bVFZXnh11eLDdPIK2f2XCmva78acPPDfJisfab7qNakwBh7hdBXw==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.3.2.tgz",
+      "integrity": "sha512-YIaEhWmfkdHEWOKwhF/oJar35FFTTrAdzNbJDo9lSsRT6E/obRPx9oVm4rkTMtlcJSqGYttNtLbcHQef9Qw2yw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/figures": "^2.0.8",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/figures": "^2.0.9",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -993,16 +993,16 @@
       }
     },
     "node_modules/@inquirer/select": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.2.3.tgz",
-      "integrity": "sha512-KuRTodDa6xBXX2noIpjuitpX/QT7Sfav7dIZ/OfUY54Hxg95nrGoshSzxx6Ey7qqLbImKdiGkSDt7KjPXjQgmA==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.2.4.tgz",
+      "integrity": "sha512-L9ubNaJdoBsiom/AfPKq0QLHTkhhCFCtszzdVidGremrlJjPZfGlmvp+IULKIbnYjtVFWnvb4mhiEdNTZ12ugA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.7",
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/figures": "^2.0.8",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/ansi": "^2.0.8",
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/figures": "^2.0.9",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -1017,9 +1017,9 @@
       }
     },
     "node_modules/@inquirer/type": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.1.0.tgz",
-      "integrity": "sha512-FMiJpuHUG3Dk0ex+UIXkre7i+i4OcwHWk9YdcVtZHFwb/r2rnrU2ipTCNAB7A+QOP0ryzIcqOfy76fRyyvOEAw==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.1.1.tgz",
+      "integrity": "sha512-yJoHYrMnxIsJZCY+0Vb66Dy3he3kL3e2wOBKhoSwWWAzZAY82emlxwgprCtp6yRixvNRNq9ztfRWQYPNr3Go7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2479,16 +2479,16 @@
       }
     },
     "node_modules/inquirer": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-14.2.0.tgz",
-      "integrity": "sha512-OUSQNF7um7AvgPyBiK6ENfjqEG434oeVkRG97U8foLftOfcJfKcTi5pMtagJe5ytANPH5TlbfVgEokAl6RSj6g==",
+      "version": "14.2.1",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-14.2.1.tgz",
+      "integrity": "sha512-jLO8986l0/jW+K2Y5BHAhrD6ztnm8MHQgnTI5BwKV6can/LN6xYBcLbtUSvDt1jXNTASwCZszZk0ZBUT5YmH6Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.7",
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/prompts": "^8.7.0",
-        "@inquirer/type": "^4.1.0",
+        "@inquirer/ansi": "^2.0.8",
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/prompts": "^8.7.1",
+        "@inquirer/type": "4.1.1",
         "mute-stream": "^3.0.0",
         "run-async": "^4.0.6"
       },

--- a/examples/forge-sql-orm-example-drizzle-driver-simple/static/forge-orm-example/package-lock.json
+++ b/examples/forge-sql-orm-example-drizzle-driver-simple/static/forge-orm-example/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@atlaskit/css-reset": "^8.4.0",
-        "@atlaskit/dynamic-table": "^19.3.1",
+        "@atlaskit/dynamic-table": "^19.3.2",
         "@forge/bridge": "^6.3.1",
         "mobx": "7.0.3",
         "mobx-react": "10.0.2",
@@ -199,9 +199,9 @@
       }
     },
     "node_modules/@atlaskit/dynamic-table": {
-      "version": "19.3.1",
-      "resolved": "https://registry.npmjs.org/@atlaskit/dynamic-table/-/dynamic-table-19.3.1.tgz",
-      "integrity": "sha512-5XFmU7E3qnYekp/Vqebp1Jo+aPHor5s4ruVRI0nuWp67zW7Efm+S02WA46dy5fHf8fCedMdTWj1pn0ehEXcVwQ==",
+      "version": "19.3.2",
+      "resolved": "https://registry.npmjs.org/@atlaskit/dynamic-table/-/dynamic-table-19.3.2.tgz",
+      "integrity": "sha512-0y5E3pvVGYujJTIFIqaCd1pBnJd7ZUNPsSEvHJKf7CiD46kkDFo5n1F29z0DwIbC1MR6gd0x+XVB28Pxb/R2jw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@atlaskit/analytics-next": "^12.5.0",
@@ -219,8 +219,8 @@
         "@compiled/react": "^1.0.2"
       },
       "peerDependencies": {
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react": "^18.2.0 || ^19.0.0",
+        "react-dom": "^18.2.0 || ^19.0.0"
       }
     },
     "node_modules/@atlaskit/editor-prosemirror": {

--- a/examples/forge-sql-orm-example-drizzle-driver-simple/static/forge-orm-example/package.json
+++ b/examples/forge-sql-orm-example-drizzle-driver-simple/static/forge-orm-example/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "dependencies": {
     "@atlaskit/css-reset": "^8.4.0",
-    "@atlaskit/dynamic-table": "^19.3.1",
+    "@atlaskit/dynamic-table": "^19.3.2",
     "@forge/bridge": "^6.3.1",
     "mobx": "7.0.3",
     "mobx-react": "10.0.2",

--- a/examples/forge-sql-orm-example-dynamic/package-lock.json
+++ b/examples/forge-sql-orm-example-dynamic/package-lock.json
@@ -672,9 +672,9 @@
       }
     },
     "node_modules/@inquirer/ansi": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.7.tgz",
-      "integrity": "sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.8.tgz",
+      "integrity": "sha512-WpQM+Ti6Z40EFwwt+uL2p4UabT+W179zHp6HhLVOzfbwnVn05IPO/eXIZXGNqcT1jbQ15SujNLzQ39k4QPPxBQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -682,16 +682,16 @@
       }
     },
     "node_modules/@inquirer/checkbox": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.2.3.tgz",
-      "integrity": "sha512-XEYX2WA8SBkLPczL6/yXPHLPCvDoptmh9v56Cy05BSV1Smk1vWy19bTC4qJBuIffw7+6l4CcaYYzGqG60RfW1g==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.2.4.tgz",
+      "integrity": "sha512-oKT5RNeO9oKYizSyOxKb66IrKUsYVMQD2tnjllYW4wmSOe9WawfL3OE2p82JuvAyo+/nDIEem5P4Bm/ZIVYVew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.7",
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/figures": "^2.0.8",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/ansi": "^2.0.8",
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/figures": "^2.0.9",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -706,14 +706,14 @@
       }
     },
     "node_modules/@inquirer/confirm": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.3.0.tgz",
-      "integrity": "sha512-pZHXJImFtERmSNMBHcjwuz8Ck5vEFEYNUZnwbb8aJpjHv/TwGuFErNxF2Hp8+V+pNJs2EYPMlyWscvFEqO9jOQ==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.3.1.tgz",
+      "integrity": "sha512-HvnOHal39DTenOVoRpIy8Z+n4YYfNa3Qhi/P8zFqn9/d1crpmQG0DPx34rwOeOFvotgKr9Vov/14OmKR/Iwfjw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -728,15 +728,15 @@
       }
     },
     "node_modules/@inquirer/core": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-12.0.1.tgz",
-      "integrity": "sha512-JMD5Jy/ScL5TZE18m83Nw25HjqGFLoWXwnEkW7IdwwAhZpB9Bus55/WU7zn3UqR1MOCjjTQOIYpiD4vjWA3LPw==",
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-12.0.2.tgz",
+      "integrity": "sha512-9pBhkxE14uUlnHhs8lOt7qVPtS4caRY6CjADl8COejl9Mf7w8i6Uoe3DrljCqYtmYM3Iv2Q6EmPxx/oTYbvTAQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.7",
-        "@inquirer/figures": "^2.0.8",
-        "@inquirer/type": "^4.1.0",
+        "@inquirer/ansi": "^2.0.8",
+        "@inquirer/figures": "^2.0.9",
+        "@inquirer/type": "4.1.1",
         "cli-width": "^4.1.0",
         "fast-wrap-ansi": "^0.2.0",
         "mute-stream": "^3.0.0",
@@ -755,15 +755,15 @@
       }
     },
     "node_modules/@inquirer/editor": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.3.1.tgz",
-      "integrity": "sha512-y43COoyVUjPWIobn2Qep/uI1drPS78aaZZZ9kVi94Tyu/GuW2N8d8Q4rifJXGAXCEAXCPTTMjD8gC1HyvM5ukA==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.3.2.tgz",
+      "integrity": "sha512-7ruKO5d/wxhGHxdCQ3eyP/aBNrPTZ+Ju7ERtnAwuIsu0RSLs6kotlTRkOxHatbD6sDaEEdwsD82pzFiT9ESIyQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/external-editor": "^3.0.4",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/external-editor": "^3.0.5",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -778,14 +778,14 @@
       }
     },
     "node_modules/@inquirer/expand": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.1.3.tgz",
-      "integrity": "sha512-3NQJiXNJ/aj9wiAsr7pECdp5Qe9J0X9YUJCKsaFXS+ddOxfL6J4AIl3w3T4Gq3kK0WsQY5GMoDokK5X94m6lHw==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.1.4.tgz",
+      "integrity": "sha512-12o4aYnjWouoq0fyVhYIL+hwXAaga+kntA/wrijFmVvn2heinkdvkbEXRt1Ob/9IOJ285US5tntjfI/Ukt2YkA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -800,9 +800,9 @@
       }
     },
     "node_modules/@inquirer/external-editor": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-3.0.4.tgz",
-      "integrity": "sha512-tZbbaK2ovq6vlrRBNQvjrypmrED/p5x2ncIHQ79cD55tei3dD96v5glMMA+6tiq7K104i/25DVYKWVPJuV6ptA==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-3.0.5.tgz",
+      "integrity": "sha512-f3QQJRIX5ZEneBHNUIuPjmbdzHnmRFJA8r2dkcb8q+OM5Uv5KtnuAttQumnrjcBVBM3mcTX1CkmtAkU58VRZxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -839,9 +839,9 @@
       }
     },
     "node_modules/@inquirer/figures": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.8.tgz",
-      "integrity": "sha512-tApbon79GM9ry56ja/Ud3SY2CL4TQsao9fIwDQbgTeNY55025GdMzQ2+UdegV/lx51VNGUB59M0v0nMpybYY4Q==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.9.tgz",
+      "integrity": "sha512-EAWgUTGQ/Umgga51dE3B2PUHbufuXarDfg86uVgoSgNHNNQnyFKcOrQLWVqYMghuSyHh8+2HUH0Js9cTC1WAdg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -849,14 +849,14 @@
       }
     },
     "node_modules/@inquirer/input": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.1.4.tgz",
-      "integrity": "sha512-3xQkQrOvgOzpSN2ciTVdRDlg1FWMCA8l+0KfB6SNlILoTCGzJTzO/gc0Rwjcb3usuGyKdaGtI6OiyMdeMeLWkg==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.1.5.tgz",
+      "integrity": "sha512-2MkYYFD1Owt1eRBwHhsLSutysRodWasA4DVpl42KJKGmzwBTXRYAIXujisrt0UW0UohUlMjNjLfMDbw4emRbfw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -871,14 +871,14 @@
       }
     },
     "node_modules/@inquirer/number": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.2.1.tgz",
-      "integrity": "sha512-5KaqwZNLRpUuWcoCrYghPP9TMaXL5v2Sk4xqePM7RCVegcJStoXdWibio60YIC1bec+z1fCyb67N6XPJIkZtGA==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.2.2.tgz",
+      "integrity": "sha512-tjW1gMIQsFb/9Ie11i8SpuPARBdyCVfC5XOeVugWovrdm8CpjzN+A1CBX5QwCCN2mtNmpgDDCnuLCCT94cQ5zA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -893,15 +893,15 @@
       }
     },
     "node_modules/@inquirer/password": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.2.0.tgz",
-      "integrity": "sha512-CvVcW09emkBESEOW+4R8CjLNkP3fB3XrjeL8CDvfpjgrJN+V9oerXmJAXXM3l+4xqYPD5Yaujzy/Ph0PLOdDuA==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.2.1.tgz",
+      "integrity": "sha512-InA6nJxMCXPavPBiTKYHIsYiWz/mkIsk1rkI6pKp5w18gVawqrZOj7eSzSmPJa3j0pVxXm6RlrFP1BE9YeOixA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.7",
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/ansi": "^2.0.8",
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -916,22 +916,22 @@
       }
     },
     "node_modules/@inquirer/prompts": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.7.0.tgz",
-      "integrity": "sha512-yQwBMYvpJ6jqrXtKiOwRD5XezjJoyt3VQvIyjsr5Arqb519nfIohOQymWVJ8/vEgg8xtZerrCsqlSaqt/LPC9A==",
+      "version": "8.7.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.7.1.tgz",
+      "integrity": "sha512-xJIKWyrFNUKj3R5VEub/iKodG9Sh/MbCeApZUbATJgHTw8YoAJ2gOT78HlvO6NMFiRvjm6ySM7aiAew/zVY0Sw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/checkbox": "^5.2.3",
-        "@inquirer/confirm": "^6.3.0",
-        "@inquirer/editor": "^5.3.1",
-        "@inquirer/expand": "^5.1.3",
-        "@inquirer/input": "^5.1.4",
-        "@inquirer/number": "^4.2.1",
-        "@inquirer/password": "^5.2.0",
-        "@inquirer/rawlist": "^5.3.3",
-        "@inquirer/search": "^4.3.1",
-        "@inquirer/select": "^5.2.3"
+        "@inquirer/checkbox": "^5.2.4",
+        "@inquirer/confirm": "^6.3.1",
+        "@inquirer/editor": "^5.3.2",
+        "@inquirer/expand": "^5.1.4",
+        "@inquirer/input": "^5.1.5",
+        "@inquirer/number": "^4.2.2",
+        "@inquirer/password": "^5.2.1",
+        "@inquirer/rawlist": "^5.3.4",
+        "@inquirer/search": "^4.3.2",
+        "@inquirer/select": "^5.2.4"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -946,14 +946,14 @@
       }
     },
     "node_modules/@inquirer/rawlist": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.3.3.tgz",
-      "integrity": "sha512-Mu7WrtmDLaXBDEyrRLS70SZgX9ZSm4Up1w0ZxiH8C1OOp9oaVCn2k8q3QGgmlnhsKYUhuaU3zFWhAP6wxkVIMA==",
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.3.4.tgz",
+      "integrity": "sha512-c4fDwOpQsjJDHjXdHJE1/xXH6w9/BAiyu3QKzH9Ww5Xm1q37mzyUNa20L7qdtM1ECi4e+oUEKjhK8hR37OMAMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -968,15 +968,15 @@
       }
     },
     "node_modules/@inquirer/search": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.3.1.tgz",
-      "integrity": "sha512-0VWOvsHWI0rPj6CG70MoP4oXNCB6adcyN8bVFZXnh11eLDdPIK2f2XCmva78acPPDfJisfab7qNakwBh7hdBXw==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.3.2.tgz",
+      "integrity": "sha512-YIaEhWmfkdHEWOKwhF/oJar35FFTTrAdzNbJDo9lSsRT6E/obRPx9oVm4rkTMtlcJSqGYttNtLbcHQef9Qw2yw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/figures": "^2.0.8",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/figures": "^2.0.9",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -991,16 +991,16 @@
       }
     },
     "node_modules/@inquirer/select": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.2.3.tgz",
-      "integrity": "sha512-KuRTodDa6xBXX2noIpjuitpX/QT7Sfav7dIZ/OfUY54Hxg95nrGoshSzxx6Ey7qqLbImKdiGkSDt7KjPXjQgmA==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.2.4.tgz",
+      "integrity": "sha512-L9ubNaJdoBsiom/AfPKq0QLHTkhhCFCtszzdVidGremrlJjPZfGlmvp+IULKIbnYjtVFWnvb4mhiEdNTZ12ugA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.7",
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/figures": "^2.0.8",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/ansi": "^2.0.8",
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/figures": "^2.0.9",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -1015,9 +1015,9 @@
       }
     },
     "node_modules/@inquirer/type": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.1.0.tgz",
-      "integrity": "sha512-FMiJpuHUG3Dk0ex+UIXkre7i+i4OcwHWk9YdcVtZHFwb/r2rnrU2ipTCNAB7A+QOP0ryzIcqOfy76fRyyvOEAw==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.1.1.tgz",
+      "integrity": "sha512-yJoHYrMnxIsJZCY+0Vb66Dy3he3kL3e2wOBKhoSwWWAzZAY82emlxwgprCtp6yRixvNRNq9ztfRWQYPNr3Go7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2477,16 +2477,16 @@
       }
     },
     "node_modules/inquirer": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-14.2.0.tgz",
-      "integrity": "sha512-OUSQNF7um7AvgPyBiK6ENfjqEG434oeVkRG97U8foLftOfcJfKcTi5pMtagJe5ytANPH5TlbfVgEokAl6RSj6g==",
+      "version": "14.2.1",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-14.2.1.tgz",
+      "integrity": "sha512-jLO8986l0/jW+K2Y5BHAhrD6ztnm8MHQgnTI5BwKV6can/LN6xYBcLbtUSvDt1jXNTASwCZszZk0ZBUT5YmH6Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.7",
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/prompts": "^8.7.0",
-        "@inquirer/type": "^4.1.0",
+        "@inquirer/ansi": "^2.0.8",
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/prompts": "^8.7.1",
+        "@inquirer/type": "4.1.1",
         "mute-stream": "^3.0.0",
         "run-async": "^4.0.6"
       },

--- a/examples/forge-sql-orm-example-dynamic/static/forge-orm-example/package-lock.json
+++ b/examples/forge-sql-orm-example-dynamic/static/forge-orm-example/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@atlaskit/css-reset": "^8.4.0",
-        "@atlaskit/dynamic-table": "^19.3.1",
+        "@atlaskit/dynamic-table": "^19.3.2",
         "@forge/bridge": "^6.3.1",
         "mobx": "7.0.3",
         "mobx-react": "10.0.2",
@@ -199,9 +199,9 @@
       }
     },
     "node_modules/@atlaskit/dynamic-table": {
-      "version": "19.3.1",
-      "resolved": "https://registry.npmjs.org/@atlaskit/dynamic-table/-/dynamic-table-19.3.1.tgz",
-      "integrity": "sha512-5XFmU7E3qnYekp/Vqebp1Jo+aPHor5s4ruVRI0nuWp67zW7Efm+S02WA46dy5fHf8fCedMdTWj1pn0ehEXcVwQ==",
+      "version": "19.3.2",
+      "resolved": "https://registry.npmjs.org/@atlaskit/dynamic-table/-/dynamic-table-19.3.2.tgz",
+      "integrity": "sha512-0y5E3pvVGYujJTIFIqaCd1pBnJd7ZUNPsSEvHJKf7CiD46kkDFo5n1F29z0DwIbC1MR6gd0x+XVB28Pxb/R2jw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@atlaskit/analytics-next": "^12.5.0",
@@ -219,8 +219,8 @@
         "@compiled/react": "^1.0.2"
       },
       "peerDependencies": {
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react": "^18.2.0 || ^19.0.0",
+        "react-dom": "^18.2.0 || ^19.0.0"
       }
     },
     "node_modules/@atlaskit/editor-prosemirror": {

--- a/examples/forge-sql-orm-example-dynamic/static/forge-orm-example/package.json
+++ b/examples/forge-sql-orm-example-dynamic/static/forge-orm-example/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "dependencies": {
     "@atlaskit/css-reset": "^8.4.0",
-    "@atlaskit/dynamic-table": "^19.3.1",
+    "@atlaskit/dynamic-table": "^19.3.2",
     "@forge/bridge": "^6.3.1",
     "mobx": "7.0.3",
     "mobx-react": "10.0.2",

--- a/examples/forge-sql-orm-example-optimistic-locking/package-lock.json
+++ b/examples/forge-sql-orm-example-optimistic-locking/package-lock.json
@@ -672,9 +672,9 @@
       }
     },
     "node_modules/@inquirer/ansi": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.7.tgz",
-      "integrity": "sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.8.tgz",
+      "integrity": "sha512-WpQM+Ti6Z40EFwwt+uL2p4UabT+W179zHp6HhLVOzfbwnVn05IPO/eXIZXGNqcT1jbQ15SujNLzQ39k4QPPxBQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -682,16 +682,16 @@
       }
     },
     "node_modules/@inquirer/checkbox": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.2.3.tgz",
-      "integrity": "sha512-XEYX2WA8SBkLPczL6/yXPHLPCvDoptmh9v56Cy05BSV1Smk1vWy19bTC4qJBuIffw7+6l4CcaYYzGqG60RfW1g==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.2.4.tgz",
+      "integrity": "sha512-oKT5RNeO9oKYizSyOxKb66IrKUsYVMQD2tnjllYW4wmSOe9WawfL3OE2p82JuvAyo+/nDIEem5P4Bm/ZIVYVew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.7",
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/figures": "^2.0.8",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/ansi": "^2.0.8",
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/figures": "^2.0.9",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -706,14 +706,14 @@
       }
     },
     "node_modules/@inquirer/confirm": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.3.0.tgz",
-      "integrity": "sha512-pZHXJImFtERmSNMBHcjwuz8Ck5vEFEYNUZnwbb8aJpjHv/TwGuFErNxF2Hp8+V+pNJs2EYPMlyWscvFEqO9jOQ==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.3.1.tgz",
+      "integrity": "sha512-HvnOHal39DTenOVoRpIy8Z+n4YYfNa3Qhi/P8zFqn9/d1crpmQG0DPx34rwOeOFvotgKr9Vov/14OmKR/Iwfjw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -728,15 +728,15 @@
       }
     },
     "node_modules/@inquirer/core": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-12.0.1.tgz",
-      "integrity": "sha512-JMD5Jy/ScL5TZE18m83Nw25HjqGFLoWXwnEkW7IdwwAhZpB9Bus55/WU7zn3UqR1MOCjjTQOIYpiD4vjWA3LPw==",
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-12.0.2.tgz",
+      "integrity": "sha512-9pBhkxE14uUlnHhs8lOt7qVPtS4caRY6CjADl8COejl9Mf7w8i6Uoe3DrljCqYtmYM3Iv2Q6EmPxx/oTYbvTAQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.7",
-        "@inquirer/figures": "^2.0.8",
-        "@inquirer/type": "^4.1.0",
+        "@inquirer/ansi": "^2.0.8",
+        "@inquirer/figures": "^2.0.9",
+        "@inquirer/type": "4.1.1",
         "cli-width": "^4.1.0",
         "fast-wrap-ansi": "^0.2.0",
         "mute-stream": "^3.0.0",
@@ -755,15 +755,15 @@
       }
     },
     "node_modules/@inquirer/editor": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.3.1.tgz",
-      "integrity": "sha512-y43COoyVUjPWIobn2Qep/uI1drPS78aaZZZ9kVi94Tyu/GuW2N8d8Q4rifJXGAXCEAXCPTTMjD8gC1HyvM5ukA==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.3.2.tgz",
+      "integrity": "sha512-7ruKO5d/wxhGHxdCQ3eyP/aBNrPTZ+Ju7ERtnAwuIsu0RSLs6kotlTRkOxHatbD6sDaEEdwsD82pzFiT9ESIyQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/external-editor": "^3.0.4",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/external-editor": "^3.0.5",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -778,14 +778,14 @@
       }
     },
     "node_modules/@inquirer/expand": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.1.3.tgz",
-      "integrity": "sha512-3NQJiXNJ/aj9wiAsr7pECdp5Qe9J0X9YUJCKsaFXS+ddOxfL6J4AIl3w3T4Gq3kK0WsQY5GMoDokK5X94m6lHw==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.1.4.tgz",
+      "integrity": "sha512-12o4aYnjWouoq0fyVhYIL+hwXAaga+kntA/wrijFmVvn2heinkdvkbEXRt1Ob/9IOJ285US5tntjfI/Ukt2YkA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -800,9 +800,9 @@
       }
     },
     "node_modules/@inquirer/external-editor": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-3.0.4.tgz",
-      "integrity": "sha512-tZbbaK2ovq6vlrRBNQvjrypmrED/p5x2ncIHQ79cD55tei3dD96v5glMMA+6tiq7K104i/25DVYKWVPJuV6ptA==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-3.0.5.tgz",
+      "integrity": "sha512-f3QQJRIX5ZEneBHNUIuPjmbdzHnmRFJA8r2dkcb8q+OM5Uv5KtnuAttQumnrjcBVBM3mcTX1CkmtAkU58VRZxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -839,9 +839,9 @@
       }
     },
     "node_modules/@inquirer/figures": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.8.tgz",
-      "integrity": "sha512-tApbon79GM9ry56ja/Ud3SY2CL4TQsao9fIwDQbgTeNY55025GdMzQ2+UdegV/lx51VNGUB59M0v0nMpybYY4Q==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.9.tgz",
+      "integrity": "sha512-EAWgUTGQ/Umgga51dE3B2PUHbufuXarDfg86uVgoSgNHNNQnyFKcOrQLWVqYMghuSyHh8+2HUH0Js9cTC1WAdg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -849,14 +849,14 @@
       }
     },
     "node_modules/@inquirer/input": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.1.4.tgz",
-      "integrity": "sha512-3xQkQrOvgOzpSN2ciTVdRDlg1FWMCA8l+0KfB6SNlILoTCGzJTzO/gc0Rwjcb3usuGyKdaGtI6OiyMdeMeLWkg==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.1.5.tgz",
+      "integrity": "sha512-2MkYYFD1Owt1eRBwHhsLSutysRodWasA4DVpl42KJKGmzwBTXRYAIXujisrt0UW0UohUlMjNjLfMDbw4emRbfw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -871,14 +871,14 @@
       }
     },
     "node_modules/@inquirer/number": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.2.1.tgz",
-      "integrity": "sha512-5KaqwZNLRpUuWcoCrYghPP9TMaXL5v2Sk4xqePM7RCVegcJStoXdWibio60YIC1bec+z1fCyb67N6XPJIkZtGA==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.2.2.tgz",
+      "integrity": "sha512-tjW1gMIQsFb/9Ie11i8SpuPARBdyCVfC5XOeVugWovrdm8CpjzN+A1CBX5QwCCN2mtNmpgDDCnuLCCT94cQ5zA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -893,15 +893,15 @@
       }
     },
     "node_modules/@inquirer/password": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.2.0.tgz",
-      "integrity": "sha512-CvVcW09emkBESEOW+4R8CjLNkP3fB3XrjeL8CDvfpjgrJN+V9oerXmJAXXM3l+4xqYPD5Yaujzy/Ph0PLOdDuA==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.2.1.tgz",
+      "integrity": "sha512-InA6nJxMCXPavPBiTKYHIsYiWz/mkIsk1rkI6pKp5w18gVawqrZOj7eSzSmPJa3j0pVxXm6RlrFP1BE9YeOixA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.7",
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/ansi": "^2.0.8",
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -916,22 +916,22 @@
       }
     },
     "node_modules/@inquirer/prompts": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.7.0.tgz",
-      "integrity": "sha512-yQwBMYvpJ6jqrXtKiOwRD5XezjJoyt3VQvIyjsr5Arqb519nfIohOQymWVJ8/vEgg8xtZerrCsqlSaqt/LPC9A==",
+      "version": "8.7.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.7.1.tgz",
+      "integrity": "sha512-xJIKWyrFNUKj3R5VEub/iKodG9Sh/MbCeApZUbATJgHTw8YoAJ2gOT78HlvO6NMFiRvjm6ySM7aiAew/zVY0Sw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/checkbox": "^5.2.3",
-        "@inquirer/confirm": "^6.3.0",
-        "@inquirer/editor": "^5.3.1",
-        "@inquirer/expand": "^5.1.3",
-        "@inquirer/input": "^5.1.4",
-        "@inquirer/number": "^4.2.1",
-        "@inquirer/password": "^5.2.0",
-        "@inquirer/rawlist": "^5.3.3",
-        "@inquirer/search": "^4.3.1",
-        "@inquirer/select": "^5.2.3"
+        "@inquirer/checkbox": "^5.2.4",
+        "@inquirer/confirm": "^6.3.1",
+        "@inquirer/editor": "^5.3.2",
+        "@inquirer/expand": "^5.1.4",
+        "@inquirer/input": "^5.1.5",
+        "@inquirer/number": "^4.2.2",
+        "@inquirer/password": "^5.2.1",
+        "@inquirer/rawlist": "^5.3.4",
+        "@inquirer/search": "^4.3.2",
+        "@inquirer/select": "^5.2.4"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -946,14 +946,14 @@
       }
     },
     "node_modules/@inquirer/rawlist": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.3.3.tgz",
-      "integrity": "sha512-Mu7WrtmDLaXBDEyrRLS70SZgX9ZSm4Up1w0ZxiH8C1OOp9oaVCn2k8q3QGgmlnhsKYUhuaU3zFWhAP6wxkVIMA==",
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.3.4.tgz",
+      "integrity": "sha512-c4fDwOpQsjJDHjXdHJE1/xXH6w9/BAiyu3QKzH9Ww5Xm1q37mzyUNa20L7qdtM1ECi4e+oUEKjhK8hR37OMAMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -968,15 +968,15 @@
       }
     },
     "node_modules/@inquirer/search": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.3.1.tgz",
-      "integrity": "sha512-0VWOvsHWI0rPj6CG70MoP4oXNCB6adcyN8bVFZXnh11eLDdPIK2f2XCmva78acPPDfJisfab7qNakwBh7hdBXw==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.3.2.tgz",
+      "integrity": "sha512-YIaEhWmfkdHEWOKwhF/oJar35FFTTrAdzNbJDo9lSsRT6E/obRPx9oVm4rkTMtlcJSqGYttNtLbcHQef9Qw2yw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/figures": "^2.0.8",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/figures": "^2.0.9",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -991,16 +991,16 @@
       }
     },
     "node_modules/@inquirer/select": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.2.3.tgz",
-      "integrity": "sha512-KuRTodDa6xBXX2noIpjuitpX/QT7Sfav7dIZ/OfUY54Hxg95nrGoshSzxx6Ey7qqLbImKdiGkSDt7KjPXjQgmA==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.2.4.tgz",
+      "integrity": "sha512-L9ubNaJdoBsiom/AfPKq0QLHTkhhCFCtszzdVidGremrlJjPZfGlmvp+IULKIbnYjtVFWnvb4mhiEdNTZ12ugA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.7",
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/figures": "^2.0.8",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/ansi": "^2.0.8",
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/figures": "^2.0.9",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -1015,9 +1015,9 @@
       }
     },
     "node_modules/@inquirer/type": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.1.0.tgz",
-      "integrity": "sha512-FMiJpuHUG3Dk0ex+UIXkre7i+i4OcwHWk9YdcVtZHFwb/r2rnrU2ipTCNAB7A+QOP0ryzIcqOfy76fRyyvOEAw==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.1.1.tgz",
+      "integrity": "sha512-yJoHYrMnxIsJZCY+0Vb66Dy3he3kL3e2wOBKhoSwWWAzZAY82emlxwgprCtp6yRixvNRNq9ztfRWQYPNr3Go7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2477,16 +2477,16 @@
       }
     },
     "node_modules/inquirer": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-14.2.0.tgz",
-      "integrity": "sha512-OUSQNF7um7AvgPyBiK6ENfjqEG434oeVkRG97U8foLftOfcJfKcTi5pMtagJe5ytANPH5TlbfVgEokAl6RSj6g==",
+      "version": "14.2.1",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-14.2.1.tgz",
+      "integrity": "sha512-jLO8986l0/jW+K2Y5BHAhrD6ztnm8MHQgnTI5BwKV6can/LN6xYBcLbtUSvDt1jXNTASwCZszZk0ZBUT5YmH6Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.7",
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/prompts": "^8.7.0",
-        "@inquirer/type": "^4.1.0",
+        "@inquirer/ansi": "^2.0.8",
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/prompts": "^8.7.1",
+        "@inquirer/type": "4.1.1",
         "mute-stream": "^3.0.0",
         "run-async": "^4.0.6"
       },

--- a/examples/forge-sql-orm-example-optimistic-locking/static/forge-orm-example/package-lock.json
+++ b/examples/forge-sql-orm-example-optimistic-locking/static/forge-orm-example/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@atlaskit/button": "^25.3.2",
         "@atlaskit/css-reset": "^8.4.0",
-        "@atlaskit/dynamic-table": "^19.3.1",
+        "@atlaskit/dynamic-table": "^19.3.2",
         "@atlaskit/tabs": "^21.2.0",
         "@atlaskit/tokens": "^16.11.2",
         "@forge/bridge": "^6.3.1",
@@ -202,9 +202,9 @@
       }
     },
     "node_modules/@atlaskit/dynamic-table": {
-      "version": "19.3.1",
-      "resolved": "https://registry.npmjs.org/@atlaskit/dynamic-table/-/dynamic-table-19.3.1.tgz",
-      "integrity": "sha512-5XFmU7E3qnYekp/Vqebp1Jo+aPHor5s4ruVRI0nuWp67zW7Efm+S02WA46dy5fHf8fCedMdTWj1pn0ehEXcVwQ==",
+      "version": "19.3.2",
+      "resolved": "https://registry.npmjs.org/@atlaskit/dynamic-table/-/dynamic-table-19.3.2.tgz",
+      "integrity": "sha512-0y5E3pvVGYujJTIFIqaCd1pBnJd7ZUNPsSEvHJKf7CiD46kkDFo5n1F29z0DwIbC1MR6gd0x+XVB28Pxb/R2jw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@atlaskit/analytics-next": "^12.5.0",
@@ -222,8 +222,8 @@
         "@compiled/react": "^1.0.2"
       },
       "peerDependencies": {
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react": "^18.2.0 || ^19.0.0",
+        "react-dom": "^18.2.0 || ^19.0.0"
       }
     },
     "node_modules/@atlaskit/editor-prosemirror": {

--- a/examples/forge-sql-orm-example-optimistic-locking/static/forge-orm-example/package.json
+++ b/examples/forge-sql-orm-example-optimistic-locking/static/forge-orm-example/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@atlaskit/button": "^25.3.2",
     "@atlaskit/css-reset": "^8.4.0",
-    "@atlaskit/dynamic-table": "^19.3.1",
+    "@atlaskit/dynamic-table": "^19.3.2",
     "@atlaskit/tabs": "^21.2.0",
     "@atlaskit/tokens": "^16.11.2",
     "@forge/bridge": "^6.3.1",

--- a/examples/forge-sql-orm-example-org-tracker/package-lock.json
+++ b/examples/forge-sql-orm-example-org-tracker/package-lock.json
@@ -672,9 +672,9 @@
       }
     },
     "node_modules/@inquirer/ansi": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.7.tgz",
-      "integrity": "sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.8.tgz",
+      "integrity": "sha512-WpQM+Ti6Z40EFwwt+uL2p4UabT+W179zHp6HhLVOzfbwnVn05IPO/eXIZXGNqcT1jbQ15SujNLzQ39k4QPPxBQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -682,16 +682,16 @@
       }
     },
     "node_modules/@inquirer/checkbox": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.2.3.tgz",
-      "integrity": "sha512-XEYX2WA8SBkLPczL6/yXPHLPCvDoptmh9v56Cy05BSV1Smk1vWy19bTC4qJBuIffw7+6l4CcaYYzGqG60RfW1g==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.2.4.tgz",
+      "integrity": "sha512-oKT5RNeO9oKYizSyOxKb66IrKUsYVMQD2tnjllYW4wmSOe9WawfL3OE2p82JuvAyo+/nDIEem5P4Bm/ZIVYVew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.7",
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/figures": "^2.0.8",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/ansi": "^2.0.8",
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/figures": "^2.0.9",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -706,14 +706,14 @@
       }
     },
     "node_modules/@inquirer/confirm": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.3.0.tgz",
-      "integrity": "sha512-pZHXJImFtERmSNMBHcjwuz8Ck5vEFEYNUZnwbb8aJpjHv/TwGuFErNxF2Hp8+V+pNJs2EYPMlyWscvFEqO9jOQ==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.3.1.tgz",
+      "integrity": "sha512-HvnOHal39DTenOVoRpIy8Z+n4YYfNa3Qhi/P8zFqn9/d1crpmQG0DPx34rwOeOFvotgKr9Vov/14OmKR/Iwfjw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -728,15 +728,15 @@
       }
     },
     "node_modules/@inquirer/core": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-12.0.1.tgz",
-      "integrity": "sha512-JMD5Jy/ScL5TZE18m83Nw25HjqGFLoWXwnEkW7IdwwAhZpB9Bus55/WU7zn3UqR1MOCjjTQOIYpiD4vjWA3LPw==",
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-12.0.2.tgz",
+      "integrity": "sha512-9pBhkxE14uUlnHhs8lOt7qVPtS4caRY6CjADl8COejl9Mf7w8i6Uoe3DrljCqYtmYM3Iv2Q6EmPxx/oTYbvTAQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.7",
-        "@inquirer/figures": "^2.0.8",
-        "@inquirer/type": "^4.1.0",
+        "@inquirer/ansi": "^2.0.8",
+        "@inquirer/figures": "^2.0.9",
+        "@inquirer/type": "4.1.1",
         "cli-width": "^4.1.0",
         "fast-wrap-ansi": "^0.2.0",
         "mute-stream": "^3.0.0",
@@ -755,15 +755,15 @@
       }
     },
     "node_modules/@inquirer/editor": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.3.1.tgz",
-      "integrity": "sha512-y43COoyVUjPWIobn2Qep/uI1drPS78aaZZZ9kVi94Tyu/GuW2N8d8Q4rifJXGAXCEAXCPTTMjD8gC1HyvM5ukA==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.3.2.tgz",
+      "integrity": "sha512-7ruKO5d/wxhGHxdCQ3eyP/aBNrPTZ+Ju7ERtnAwuIsu0RSLs6kotlTRkOxHatbD6sDaEEdwsD82pzFiT9ESIyQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/external-editor": "^3.0.4",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/external-editor": "^3.0.5",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -778,14 +778,14 @@
       }
     },
     "node_modules/@inquirer/expand": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.1.3.tgz",
-      "integrity": "sha512-3NQJiXNJ/aj9wiAsr7pECdp5Qe9J0X9YUJCKsaFXS+ddOxfL6J4AIl3w3T4Gq3kK0WsQY5GMoDokK5X94m6lHw==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.1.4.tgz",
+      "integrity": "sha512-12o4aYnjWouoq0fyVhYIL+hwXAaga+kntA/wrijFmVvn2heinkdvkbEXRt1Ob/9IOJ285US5tntjfI/Ukt2YkA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -800,9 +800,9 @@
       }
     },
     "node_modules/@inquirer/external-editor": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-3.0.4.tgz",
-      "integrity": "sha512-tZbbaK2ovq6vlrRBNQvjrypmrED/p5x2ncIHQ79cD55tei3dD96v5glMMA+6tiq7K104i/25DVYKWVPJuV6ptA==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-3.0.5.tgz",
+      "integrity": "sha512-f3QQJRIX5ZEneBHNUIuPjmbdzHnmRFJA8r2dkcb8q+OM5Uv5KtnuAttQumnrjcBVBM3mcTX1CkmtAkU58VRZxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -839,9 +839,9 @@
       }
     },
     "node_modules/@inquirer/figures": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.8.tgz",
-      "integrity": "sha512-tApbon79GM9ry56ja/Ud3SY2CL4TQsao9fIwDQbgTeNY55025GdMzQ2+UdegV/lx51VNGUB59M0v0nMpybYY4Q==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.9.tgz",
+      "integrity": "sha512-EAWgUTGQ/Umgga51dE3B2PUHbufuXarDfg86uVgoSgNHNNQnyFKcOrQLWVqYMghuSyHh8+2HUH0Js9cTC1WAdg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -849,14 +849,14 @@
       }
     },
     "node_modules/@inquirer/input": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.1.4.tgz",
-      "integrity": "sha512-3xQkQrOvgOzpSN2ciTVdRDlg1FWMCA8l+0KfB6SNlILoTCGzJTzO/gc0Rwjcb3usuGyKdaGtI6OiyMdeMeLWkg==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.1.5.tgz",
+      "integrity": "sha512-2MkYYFD1Owt1eRBwHhsLSutysRodWasA4DVpl42KJKGmzwBTXRYAIXujisrt0UW0UohUlMjNjLfMDbw4emRbfw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -871,14 +871,14 @@
       }
     },
     "node_modules/@inquirer/number": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.2.1.tgz",
-      "integrity": "sha512-5KaqwZNLRpUuWcoCrYghPP9TMaXL5v2Sk4xqePM7RCVegcJStoXdWibio60YIC1bec+z1fCyb67N6XPJIkZtGA==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.2.2.tgz",
+      "integrity": "sha512-tjW1gMIQsFb/9Ie11i8SpuPARBdyCVfC5XOeVugWovrdm8CpjzN+A1CBX5QwCCN2mtNmpgDDCnuLCCT94cQ5zA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -893,15 +893,15 @@
       }
     },
     "node_modules/@inquirer/password": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.2.0.tgz",
-      "integrity": "sha512-CvVcW09emkBESEOW+4R8CjLNkP3fB3XrjeL8CDvfpjgrJN+V9oerXmJAXXM3l+4xqYPD5Yaujzy/Ph0PLOdDuA==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.2.1.tgz",
+      "integrity": "sha512-InA6nJxMCXPavPBiTKYHIsYiWz/mkIsk1rkI6pKp5w18gVawqrZOj7eSzSmPJa3j0pVxXm6RlrFP1BE9YeOixA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.7",
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/ansi": "^2.0.8",
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -916,22 +916,22 @@
       }
     },
     "node_modules/@inquirer/prompts": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.7.0.tgz",
-      "integrity": "sha512-yQwBMYvpJ6jqrXtKiOwRD5XezjJoyt3VQvIyjsr5Arqb519nfIohOQymWVJ8/vEgg8xtZerrCsqlSaqt/LPC9A==",
+      "version": "8.7.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.7.1.tgz",
+      "integrity": "sha512-xJIKWyrFNUKj3R5VEub/iKodG9Sh/MbCeApZUbATJgHTw8YoAJ2gOT78HlvO6NMFiRvjm6ySM7aiAew/zVY0Sw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/checkbox": "^5.2.3",
-        "@inquirer/confirm": "^6.3.0",
-        "@inquirer/editor": "^5.3.1",
-        "@inquirer/expand": "^5.1.3",
-        "@inquirer/input": "^5.1.4",
-        "@inquirer/number": "^4.2.1",
-        "@inquirer/password": "^5.2.0",
-        "@inquirer/rawlist": "^5.3.3",
-        "@inquirer/search": "^4.3.1",
-        "@inquirer/select": "^5.2.3"
+        "@inquirer/checkbox": "^5.2.4",
+        "@inquirer/confirm": "^6.3.1",
+        "@inquirer/editor": "^5.3.2",
+        "@inquirer/expand": "^5.1.4",
+        "@inquirer/input": "^5.1.5",
+        "@inquirer/number": "^4.2.2",
+        "@inquirer/password": "^5.2.1",
+        "@inquirer/rawlist": "^5.3.4",
+        "@inquirer/search": "^4.3.2",
+        "@inquirer/select": "^5.2.4"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -946,14 +946,14 @@
       }
     },
     "node_modules/@inquirer/rawlist": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.3.3.tgz",
-      "integrity": "sha512-Mu7WrtmDLaXBDEyrRLS70SZgX9ZSm4Up1w0ZxiH8C1OOp9oaVCn2k8q3QGgmlnhsKYUhuaU3zFWhAP6wxkVIMA==",
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.3.4.tgz",
+      "integrity": "sha512-c4fDwOpQsjJDHjXdHJE1/xXH6w9/BAiyu3QKzH9Ww5Xm1q37mzyUNa20L7qdtM1ECi4e+oUEKjhK8hR37OMAMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -968,15 +968,15 @@
       }
     },
     "node_modules/@inquirer/search": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.3.1.tgz",
-      "integrity": "sha512-0VWOvsHWI0rPj6CG70MoP4oXNCB6adcyN8bVFZXnh11eLDdPIK2f2XCmva78acPPDfJisfab7qNakwBh7hdBXw==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.3.2.tgz",
+      "integrity": "sha512-YIaEhWmfkdHEWOKwhF/oJar35FFTTrAdzNbJDo9lSsRT6E/obRPx9oVm4rkTMtlcJSqGYttNtLbcHQef9Qw2yw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/figures": "^2.0.8",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/figures": "^2.0.9",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -991,16 +991,16 @@
       }
     },
     "node_modules/@inquirer/select": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.2.3.tgz",
-      "integrity": "sha512-KuRTodDa6xBXX2noIpjuitpX/QT7Sfav7dIZ/OfUY54Hxg95nrGoshSzxx6Ey7qqLbImKdiGkSDt7KjPXjQgmA==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.2.4.tgz",
+      "integrity": "sha512-L9ubNaJdoBsiom/AfPKq0QLHTkhhCFCtszzdVidGremrlJjPZfGlmvp+IULKIbnYjtVFWnvb4mhiEdNTZ12ugA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.7",
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/figures": "^2.0.8",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/ansi": "^2.0.8",
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/figures": "^2.0.9",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -1015,9 +1015,9 @@
       }
     },
     "node_modules/@inquirer/type": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.1.0.tgz",
-      "integrity": "sha512-FMiJpuHUG3Dk0ex+UIXkre7i+i4OcwHWk9YdcVtZHFwb/r2rnrU2ipTCNAB7A+QOP0ryzIcqOfy76fRyyvOEAw==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.1.1.tgz",
+      "integrity": "sha512-yJoHYrMnxIsJZCY+0Vb66Dy3he3kL3e2wOBKhoSwWWAzZAY82emlxwgprCtp6yRixvNRNq9ztfRWQYPNr3Go7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2477,16 +2477,16 @@
       }
     },
     "node_modules/inquirer": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-14.2.0.tgz",
-      "integrity": "sha512-OUSQNF7um7AvgPyBiK6ENfjqEG434oeVkRG97U8foLftOfcJfKcTi5pMtagJe5ytANPH5TlbfVgEokAl6RSj6g==",
+      "version": "14.2.1",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-14.2.1.tgz",
+      "integrity": "sha512-jLO8986l0/jW+K2Y5BHAhrD6ztnm8MHQgnTI5BwKV6can/LN6xYBcLbtUSvDt1jXNTASwCZszZk0ZBUT5YmH6Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.7",
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/prompts": "^8.7.0",
-        "@inquirer/type": "^4.1.0",
+        "@inquirer/ansi": "^2.0.8",
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/prompts": "^8.7.1",
+        "@inquirer/type": "4.1.1",
         "mute-stream": "^3.0.0",
         "run-async": "^4.0.6"
       },

--- a/examples/forge-sql-orm-example-query-analyses/package-lock.json
+++ b/examples/forge-sql-orm-example-query-analyses/package-lock.json
@@ -673,9 +673,9 @@
       }
     },
     "node_modules/@inquirer/ansi": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.7.tgz",
-      "integrity": "sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.8.tgz",
+      "integrity": "sha512-WpQM+Ti6Z40EFwwt+uL2p4UabT+W179zHp6HhLVOzfbwnVn05IPO/eXIZXGNqcT1jbQ15SujNLzQ39k4QPPxBQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -683,16 +683,16 @@
       }
     },
     "node_modules/@inquirer/checkbox": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.2.3.tgz",
-      "integrity": "sha512-XEYX2WA8SBkLPczL6/yXPHLPCvDoptmh9v56Cy05BSV1Smk1vWy19bTC4qJBuIffw7+6l4CcaYYzGqG60RfW1g==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.2.4.tgz",
+      "integrity": "sha512-oKT5RNeO9oKYizSyOxKb66IrKUsYVMQD2tnjllYW4wmSOe9WawfL3OE2p82JuvAyo+/nDIEem5P4Bm/ZIVYVew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.7",
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/figures": "^2.0.8",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/ansi": "^2.0.8",
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/figures": "^2.0.9",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -707,14 +707,14 @@
       }
     },
     "node_modules/@inquirer/confirm": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.3.0.tgz",
-      "integrity": "sha512-pZHXJImFtERmSNMBHcjwuz8Ck5vEFEYNUZnwbb8aJpjHv/TwGuFErNxF2Hp8+V+pNJs2EYPMlyWscvFEqO9jOQ==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.3.1.tgz",
+      "integrity": "sha512-HvnOHal39DTenOVoRpIy8Z+n4YYfNa3Qhi/P8zFqn9/d1crpmQG0DPx34rwOeOFvotgKr9Vov/14OmKR/Iwfjw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -729,15 +729,15 @@
       }
     },
     "node_modules/@inquirer/core": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-12.0.1.tgz",
-      "integrity": "sha512-JMD5Jy/ScL5TZE18m83Nw25HjqGFLoWXwnEkW7IdwwAhZpB9Bus55/WU7zn3UqR1MOCjjTQOIYpiD4vjWA3LPw==",
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-12.0.2.tgz",
+      "integrity": "sha512-9pBhkxE14uUlnHhs8lOt7qVPtS4caRY6CjADl8COejl9Mf7w8i6Uoe3DrljCqYtmYM3Iv2Q6EmPxx/oTYbvTAQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.7",
-        "@inquirer/figures": "^2.0.8",
-        "@inquirer/type": "^4.1.0",
+        "@inquirer/ansi": "^2.0.8",
+        "@inquirer/figures": "^2.0.9",
+        "@inquirer/type": "4.1.1",
         "cli-width": "^4.1.0",
         "fast-wrap-ansi": "^0.2.0",
         "mute-stream": "^3.0.0",
@@ -756,15 +756,15 @@
       }
     },
     "node_modules/@inquirer/editor": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.3.1.tgz",
-      "integrity": "sha512-y43COoyVUjPWIobn2Qep/uI1drPS78aaZZZ9kVi94Tyu/GuW2N8d8Q4rifJXGAXCEAXCPTTMjD8gC1HyvM5ukA==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.3.2.tgz",
+      "integrity": "sha512-7ruKO5d/wxhGHxdCQ3eyP/aBNrPTZ+Ju7ERtnAwuIsu0RSLs6kotlTRkOxHatbD6sDaEEdwsD82pzFiT9ESIyQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/external-editor": "^3.0.4",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/external-editor": "^3.0.5",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -779,14 +779,14 @@
       }
     },
     "node_modules/@inquirer/expand": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.1.3.tgz",
-      "integrity": "sha512-3NQJiXNJ/aj9wiAsr7pECdp5Qe9J0X9YUJCKsaFXS+ddOxfL6J4AIl3w3T4Gq3kK0WsQY5GMoDokK5X94m6lHw==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.1.4.tgz",
+      "integrity": "sha512-12o4aYnjWouoq0fyVhYIL+hwXAaga+kntA/wrijFmVvn2heinkdvkbEXRt1Ob/9IOJ285US5tntjfI/Ukt2YkA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -801,9 +801,9 @@
       }
     },
     "node_modules/@inquirer/external-editor": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-3.0.4.tgz",
-      "integrity": "sha512-tZbbaK2ovq6vlrRBNQvjrypmrED/p5x2ncIHQ79cD55tei3dD96v5glMMA+6tiq7K104i/25DVYKWVPJuV6ptA==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-3.0.5.tgz",
+      "integrity": "sha512-f3QQJRIX5ZEneBHNUIuPjmbdzHnmRFJA8r2dkcb8q+OM5Uv5KtnuAttQumnrjcBVBM3mcTX1CkmtAkU58VRZxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -840,9 +840,9 @@
       }
     },
     "node_modules/@inquirer/figures": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.8.tgz",
-      "integrity": "sha512-tApbon79GM9ry56ja/Ud3SY2CL4TQsao9fIwDQbgTeNY55025GdMzQ2+UdegV/lx51VNGUB59M0v0nMpybYY4Q==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.9.tgz",
+      "integrity": "sha512-EAWgUTGQ/Umgga51dE3B2PUHbufuXarDfg86uVgoSgNHNNQnyFKcOrQLWVqYMghuSyHh8+2HUH0Js9cTC1WAdg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -850,14 +850,14 @@
       }
     },
     "node_modules/@inquirer/input": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.1.4.tgz",
-      "integrity": "sha512-3xQkQrOvgOzpSN2ciTVdRDlg1FWMCA8l+0KfB6SNlILoTCGzJTzO/gc0Rwjcb3usuGyKdaGtI6OiyMdeMeLWkg==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.1.5.tgz",
+      "integrity": "sha512-2MkYYFD1Owt1eRBwHhsLSutysRodWasA4DVpl42KJKGmzwBTXRYAIXujisrt0UW0UohUlMjNjLfMDbw4emRbfw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -872,14 +872,14 @@
       }
     },
     "node_modules/@inquirer/number": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.2.1.tgz",
-      "integrity": "sha512-5KaqwZNLRpUuWcoCrYghPP9TMaXL5v2Sk4xqePM7RCVegcJStoXdWibio60YIC1bec+z1fCyb67N6XPJIkZtGA==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.2.2.tgz",
+      "integrity": "sha512-tjW1gMIQsFb/9Ie11i8SpuPARBdyCVfC5XOeVugWovrdm8CpjzN+A1CBX5QwCCN2mtNmpgDDCnuLCCT94cQ5zA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -894,15 +894,15 @@
       }
     },
     "node_modules/@inquirer/password": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.2.0.tgz",
-      "integrity": "sha512-CvVcW09emkBESEOW+4R8CjLNkP3fB3XrjeL8CDvfpjgrJN+V9oerXmJAXXM3l+4xqYPD5Yaujzy/Ph0PLOdDuA==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.2.1.tgz",
+      "integrity": "sha512-InA6nJxMCXPavPBiTKYHIsYiWz/mkIsk1rkI6pKp5w18gVawqrZOj7eSzSmPJa3j0pVxXm6RlrFP1BE9YeOixA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.7",
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/ansi": "^2.0.8",
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -917,22 +917,22 @@
       }
     },
     "node_modules/@inquirer/prompts": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.7.0.tgz",
-      "integrity": "sha512-yQwBMYvpJ6jqrXtKiOwRD5XezjJoyt3VQvIyjsr5Arqb519nfIohOQymWVJ8/vEgg8xtZerrCsqlSaqt/LPC9A==",
+      "version": "8.7.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.7.1.tgz",
+      "integrity": "sha512-xJIKWyrFNUKj3R5VEub/iKodG9Sh/MbCeApZUbATJgHTw8YoAJ2gOT78HlvO6NMFiRvjm6ySM7aiAew/zVY0Sw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/checkbox": "^5.2.3",
-        "@inquirer/confirm": "^6.3.0",
-        "@inquirer/editor": "^5.3.1",
-        "@inquirer/expand": "^5.1.3",
-        "@inquirer/input": "^5.1.4",
-        "@inquirer/number": "^4.2.1",
-        "@inquirer/password": "^5.2.0",
-        "@inquirer/rawlist": "^5.3.3",
-        "@inquirer/search": "^4.3.1",
-        "@inquirer/select": "^5.2.3"
+        "@inquirer/checkbox": "^5.2.4",
+        "@inquirer/confirm": "^6.3.1",
+        "@inquirer/editor": "^5.3.2",
+        "@inquirer/expand": "^5.1.4",
+        "@inquirer/input": "^5.1.5",
+        "@inquirer/number": "^4.2.2",
+        "@inquirer/password": "^5.2.1",
+        "@inquirer/rawlist": "^5.3.4",
+        "@inquirer/search": "^4.3.2",
+        "@inquirer/select": "^5.2.4"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -947,14 +947,14 @@
       }
     },
     "node_modules/@inquirer/rawlist": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.3.3.tgz",
-      "integrity": "sha512-Mu7WrtmDLaXBDEyrRLS70SZgX9ZSm4Up1w0ZxiH8C1OOp9oaVCn2k8q3QGgmlnhsKYUhuaU3zFWhAP6wxkVIMA==",
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.3.4.tgz",
+      "integrity": "sha512-c4fDwOpQsjJDHjXdHJE1/xXH6w9/BAiyu3QKzH9Ww5Xm1q37mzyUNa20L7qdtM1ECi4e+oUEKjhK8hR37OMAMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -969,15 +969,15 @@
       }
     },
     "node_modules/@inquirer/search": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.3.1.tgz",
-      "integrity": "sha512-0VWOvsHWI0rPj6CG70MoP4oXNCB6adcyN8bVFZXnh11eLDdPIK2f2XCmva78acPPDfJisfab7qNakwBh7hdBXw==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.3.2.tgz",
+      "integrity": "sha512-YIaEhWmfkdHEWOKwhF/oJar35FFTTrAdzNbJDo9lSsRT6E/obRPx9oVm4rkTMtlcJSqGYttNtLbcHQef9Qw2yw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/figures": "^2.0.8",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/figures": "^2.0.9",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -992,16 +992,16 @@
       }
     },
     "node_modules/@inquirer/select": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.2.3.tgz",
-      "integrity": "sha512-KuRTodDa6xBXX2noIpjuitpX/QT7Sfav7dIZ/OfUY54Hxg95nrGoshSzxx6Ey7qqLbImKdiGkSDt7KjPXjQgmA==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.2.4.tgz",
+      "integrity": "sha512-L9ubNaJdoBsiom/AfPKq0QLHTkhhCFCtszzdVidGremrlJjPZfGlmvp+IULKIbnYjtVFWnvb4mhiEdNTZ12ugA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.7",
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/figures": "^2.0.8",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/ansi": "^2.0.8",
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/figures": "^2.0.9",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -1016,9 +1016,9 @@
       }
     },
     "node_modules/@inquirer/type": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.1.0.tgz",
-      "integrity": "sha512-FMiJpuHUG3Dk0ex+UIXkre7i+i4OcwHWk9YdcVtZHFwb/r2rnrU2ipTCNAB7A+QOP0ryzIcqOfy76fRyyvOEAw==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.1.1.tgz",
+      "integrity": "sha512-yJoHYrMnxIsJZCY+0Vb66Dy3he3kL3e2wOBKhoSwWWAzZAY82emlxwgprCtp6yRixvNRNq9ztfRWQYPNr3Go7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2478,16 +2478,16 @@
       }
     },
     "node_modules/inquirer": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-14.2.0.tgz",
-      "integrity": "sha512-OUSQNF7um7AvgPyBiK6ENfjqEG434oeVkRG97U8foLftOfcJfKcTi5pMtagJe5ytANPH5TlbfVgEokAl6RSj6g==",
+      "version": "14.2.1",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-14.2.1.tgz",
+      "integrity": "sha512-jLO8986l0/jW+K2Y5BHAhrD6ztnm8MHQgnTI5BwKV6can/LN6xYBcLbtUSvDt1jXNTASwCZszZk0ZBUT5YmH6Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.7",
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/prompts": "^8.7.0",
-        "@inquirer/type": "^4.1.0",
+        "@inquirer/ansi": "^2.0.8",
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/prompts": "^8.7.1",
+        "@inquirer/type": "4.1.1",
         "mute-stream": "^3.0.0",
         "run-async": "^4.0.6"
       },

--- a/examples/forge-sql-orm-example-query-analyses/static/forge-orm-example/package-lock.json
+++ b/examples/forge-sql-orm-example-query-analyses/static/forge-orm-example/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@atlaskit/css-reset": "^8.4.0",
-        "@atlaskit/dynamic-table": "^19.3.1",
+        "@atlaskit/dynamic-table": "^19.3.2",
         "@forge/bridge": "^6.3.1",
         "forge-sql-orm": "^2.2.3",
         "mobx": "7.0.3",
@@ -200,9 +200,9 @@
       }
     },
     "node_modules/@atlaskit/dynamic-table": {
-      "version": "19.3.1",
-      "resolved": "https://registry.npmjs.org/@atlaskit/dynamic-table/-/dynamic-table-19.3.1.tgz",
-      "integrity": "sha512-5XFmU7E3qnYekp/Vqebp1Jo+aPHor5s4ruVRI0nuWp67zW7Efm+S02WA46dy5fHf8fCedMdTWj1pn0ehEXcVwQ==",
+      "version": "19.3.2",
+      "resolved": "https://registry.npmjs.org/@atlaskit/dynamic-table/-/dynamic-table-19.3.2.tgz",
+      "integrity": "sha512-0y5E3pvVGYujJTIFIqaCd1pBnJd7ZUNPsSEvHJKf7CiD46kkDFo5n1F29z0DwIbC1MR6gd0x+XVB28Pxb/R2jw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@atlaskit/analytics-next": "^12.5.0",
@@ -220,8 +220,8 @@
         "@compiled/react": "^1.0.2"
       },
       "peerDependencies": {
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react": "^18.2.0 || ^19.0.0",
+        "react-dom": "^18.2.0 || ^19.0.0"
       }
     },
     "node_modules/@atlaskit/editor-prosemirror": {

--- a/examples/forge-sql-orm-example-query-analyses/static/forge-orm-example/package.json
+++ b/examples/forge-sql-orm-example-query-analyses/static/forge-orm-example/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "dependencies": {
     "@atlaskit/css-reset": "^8.4.0",
-    "@atlaskit/dynamic-table": "^19.3.1",
+    "@atlaskit/dynamic-table": "^19.3.2",
     "@forge/bridge": "^6.3.1",
     "forge-sql-orm": "^2.2.3",
     "mobx": "7.0.3",

--- a/examples/forge-sql-orm-example-simple/package-lock.json
+++ b/examples/forge-sql-orm-example-simple/package-lock.json
@@ -672,9 +672,9 @@
       }
     },
     "node_modules/@inquirer/ansi": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.7.tgz",
-      "integrity": "sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.8.tgz",
+      "integrity": "sha512-WpQM+Ti6Z40EFwwt+uL2p4UabT+W179zHp6HhLVOzfbwnVn05IPO/eXIZXGNqcT1jbQ15SujNLzQ39k4QPPxBQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -682,16 +682,16 @@
       }
     },
     "node_modules/@inquirer/checkbox": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.2.3.tgz",
-      "integrity": "sha512-XEYX2WA8SBkLPczL6/yXPHLPCvDoptmh9v56Cy05BSV1Smk1vWy19bTC4qJBuIffw7+6l4CcaYYzGqG60RfW1g==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.2.4.tgz",
+      "integrity": "sha512-oKT5RNeO9oKYizSyOxKb66IrKUsYVMQD2tnjllYW4wmSOe9WawfL3OE2p82JuvAyo+/nDIEem5P4Bm/ZIVYVew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.7",
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/figures": "^2.0.8",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/ansi": "^2.0.8",
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/figures": "^2.0.9",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -706,14 +706,14 @@
       }
     },
     "node_modules/@inquirer/confirm": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.3.0.tgz",
-      "integrity": "sha512-pZHXJImFtERmSNMBHcjwuz8Ck5vEFEYNUZnwbb8aJpjHv/TwGuFErNxF2Hp8+V+pNJs2EYPMlyWscvFEqO9jOQ==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.3.1.tgz",
+      "integrity": "sha512-HvnOHal39DTenOVoRpIy8Z+n4YYfNa3Qhi/P8zFqn9/d1crpmQG0DPx34rwOeOFvotgKr9Vov/14OmKR/Iwfjw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -728,15 +728,15 @@
       }
     },
     "node_modules/@inquirer/core": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-12.0.1.tgz",
-      "integrity": "sha512-JMD5Jy/ScL5TZE18m83Nw25HjqGFLoWXwnEkW7IdwwAhZpB9Bus55/WU7zn3UqR1MOCjjTQOIYpiD4vjWA3LPw==",
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-12.0.2.tgz",
+      "integrity": "sha512-9pBhkxE14uUlnHhs8lOt7qVPtS4caRY6CjADl8COejl9Mf7w8i6Uoe3DrljCqYtmYM3Iv2Q6EmPxx/oTYbvTAQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.7",
-        "@inquirer/figures": "^2.0.8",
-        "@inquirer/type": "^4.1.0",
+        "@inquirer/ansi": "^2.0.8",
+        "@inquirer/figures": "^2.0.9",
+        "@inquirer/type": "4.1.1",
         "cli-width": "^4.1.0",
         "fast-wrap-ansi": "^0.2.0",
         "mute-stream": "^3.0.0",
@@ -755,15 +755,15 @@
       }
     },
     "node_modules/@inquirer/editor": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.3.1.tgz",
-      "integrity": "sha512-y43COoyVUjPWIobn2Qep/uI1drPS78aaZZZ9kVi94Tyu/GuW2N8d8Q4rifJXGAXCEAXCPTTMjD8gC1HyvM5ukA==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.3.2.tgz",
+      "integrity": "sha512-7ruKO5d/wxhGHxdCQ3eyP/aBNrPTZ+Ju7ERtnAwuIsu0RSLs6kotlTRkOxHatbD6sDaEEdwsD82pzFiT9ESIyQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/external-editor": "^3.0.4",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/external-editor": "^3.0.5",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -778,14 +778,14 @@
       }
     },
     "node_modules/@inquirer/expand": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.1.3.tgz",
-      "integrity": "sha512-3NQJiXNJ/aj9wiAsr7pECdp5Qe9J0X9YUJCKsaFXS+ddOxfL6J4AIl3w3T4Gq3kK0WsQY5GMoDokK5X94m6lHw==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.1.4.tgz",
+      "integrity": "sha512-12o4aYnjWouoq0fyVhYIL+hwXAaga+kntA/wrijFmVvn2heinkdvkbEXRt1Ob/9IOJ285US5tntjfI/Ukt2YkA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -800,9 +800,9 @@
       }
     },
     "node_modules/@inquirer/external-editor": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-3.0.4.tgz",
-      "integrity": "sha512-tZbbaK2ovq6vlrRBNQvjrypmrED/p5x2ncIHQ79cD55tei3dD96v5glMMA+6tiq7K104i/25DVYKWVPJuV6ptA==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-3.0.5.tgz",
+      "integrity": "sha512-f3QQJRIX5ZEneBHNUIuPjmbdzHnmRFJA8r2dkcb8q+OM5Uv5KtnuAttQumnrjcBVBM3mcTX1CkmtAkU58VRZxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -839,9 +839,9 @@
       }
     },
     "node_modules/@inquirer/figures": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.8.tgz",
-      "integrity": "sha512-tApbon79GM9ry56ja/Ud3SY2CL4TQsao9fIwDQbgTeNY55025GdMzQ2+UdegV/lx51VNGUB59M0v0nMpybYY4Q==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.9.tgz",
+      "integrity": "sha512-EAWgUTGQ/Umgga51dE3B2PUHbufuXarDfg86uVgoSgNHNNQnyFKcOrQLWVqYMghuSyHh8+2HUH0Js9cTC1WAdg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -849,14 +849,14 @@
       }
     },
     "node_modules/@inquirer/input": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.1.4.tgz",
-      "integrity": "sha512-3xQkQrOvgOzpSN2ciTVdRDlg1FWMCA8l+0KfB6SNlILoTCGzJTzO/gc0Rwjcb3usuGyKdaGtI6OiyMdeMeLWkg==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.1.5.tgz",
+      "integrity": "sha512-2MkYYFD1Owt1eRBwHhsLSutysRodWasA4DVpl42KJKGmzwBTXRYAIXujisrt0UW0UohUlMjNjLfMDbw4emRbfw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -871,14 +871,14 @@
       }
     },
     "node_modules/@inquirer/number": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.2.1.tgz",
-      "integrity": "sha512-5KaqwZNLRpUuWcoCrYghPP9TMaXL5v2Sk4xqePM7RCVegcJStoXdWibio60YIC1bec+z1fCyb67N6XPJIkZtGA==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.2.2.tgz",
+      "integrity": "sha512-tjW1gMIQsFb/9Ie11i8SpuPARBdyCVfC5XOeVugWovrdm8CpjzN+A1CBX5QwCCN2mtNmpgDDCnuLCCT94cQ5zA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -893,15 +893,15 @@
       }
     },
     "node_modules/@inquirer/password": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.2.0.tgz",
-      "integrity": "sha512-CvVcW09emkBESEOW+4R8CjLNkP3fB3XrjeL8CDvfpjgrJN+V9oerXmJAXXM3l+4xqYPD5Yaujzy/Ph0PLOdDuA==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.2.1.tgz",
+      "integrity": "sha512-InA6nJxMCXPavPBiTKYHIsYiWz/mkIsk1rkI6pKp5w18gVawqrZOj7eSzSmPJa3j0pVxXm6RlrFP1BE9YeOixA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.7",
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/ansi": "^2.0.8",
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -916,22 +916,22 @@
       }
     },
     "node_modules/@inquirer/prompts": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.7.0.tgz",
-      "integrity": "sha512-yQwBMYvpJ6jqrXtKiOwRD5XezjJoyt3VQvIyjsr5Arqb519nfIohOQymWVJ8/vEgg8xtZerrCsqlSaqt/LPC9A==",
+      "version": "8.7.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.7.1.tgz",
+      "integrity": "sha512-xJIKWyrFNUKj3R5VEub/iKodG9Sh/MbCeApZUbATJgHTw8YoAJ2gOT78HlvO6NMFiRvjm6ySM7aiAew/zVY0Sw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/checkbox": "^5.2.3",
-        "@inquirer/confirm": "^6.3.0",
-        "@inquirer/editor": "^5.3.1",
-        "@inquirer/expand": "^5.1.3",
-        "@inquirer/input": "^5.1.4",
-        "@inquirer/number": "^4.2.1",
-        "@inquirer/password": "^5.2.0",
-        "@inquirer/rawlist": "^5.3.3",
-        "@inquirer/search": "^4.3.1",
-        "@inquirer/select": "^5.2.3"
+        "@inquirer/checkbox": "^5.2.4",
+        "@inquirer/confirm": "^6.3.1",
+        "@inquirer/editor": "^5.3.2",
+        "@inquirer/expand": "^5.1.4",
+        "@inquirer/input": "^5.1.5",
+        "@inquirer/number": "^4.2.2",
+        "@inquirer/password": "^5.2.1",
+        "@inquirer/rawlist": "^5.3.4",
+        "@inquirer/search": "^4.3.2",
+        "@inquirer/select": "^5.2.4"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -946,14 +946,14 @@
       }
     },
     "node_modules/@inquirer/rawlist": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.3.3.tgz",
-      "integrity": "sha512-Mu7WrtmDLaXBDEyrRLS70SZgX9ZSm4Up1w0ZxiH8C1OOp9oaVCn2k8q3QGgmlnhsKYUhuaU3zFWhAP6wxkVIMA==",
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.3.4.tgz",
+      "integrity": "sha512-c4fDwOpQsjJDHjXdHJE1/xXH6w9/BAiyu3QKzH9Ww5Xm1q37mzyUNa20L7qdtM1ECi4e+oUEKjhK8hR37OMAMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -968,15 +968,15 @@
       }
     },
     "node_modules/@inquirer/search": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.3.1.tgz",
-      "integrity": "sha512-0VWOvsHWI0rPj6CG70MoP4oXNCB6adcyN8bVFZXnh11eLDdPIK2f2XCmva78acPPDfJisfab7qNakwBh7hdBXw==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.3.2.tgz",
+      "integrity": "sha512-YIaEhWmfkdHEWOKwhF/oJar35FFTTrAdzNbJDo9lSsRT6E/obRPx9oVm4rkTMtlcJSqGYttNtLbcHQef9Qw2yw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/figures": "^2.0.8",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/figures": "^2.0.9",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -991,16 +991,16 @@
       }
     },
     "node_modules/@inquirer/select": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.2.3.tgz",
-      "integrity": "sha512-KuRTodDa6xBXX2noIpjuitpX/QT7Sfav7dIZ/OfUY54Hxg95nrGoshSzxx6Ey7qqLbImKdiGkSDt7KjPXjQgmA==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.2.4.tgz",
+      "integrity": "sha512-L9ubNaJdoBsiom/AfPKq0QLHTkhhCFCtszzdVidGremrlJjPZfGlmvp+IULKIbnYjtVFWnvb4mhiEdNTZ12ugA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.7",
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/figures": "^2.0.8",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/ansi": "^2.0.8",
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/figures": "^2.0.9",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -1015,9 +1015,9 @@
       }
     },
     "node_modules/@inquirer/type": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.1.0.tgz",
-      "integrity": "sha512-FMiJpuHUG3Dk0ex+UIXkre7i+i4OcwHWk9YdcVtZHFwb/r2rnrU2ipTCNAB7A+QOP0ryzIcqOfy76fRyyvOEAw==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.1.1.tgz",
+      "integrity": "sha512-yJoHYrMnxIsJZCY+0Vb66Dy3he3kL3e2wOBKhoSwWWAzZAY82emlxwgprCtp6yRixvNRNq9ztfRWQYPNr3Go7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2477,16 +2477,16 @@
       }
     },
     "node_modules/inquirer": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-14.2.0.tgz",
-      "integrity": "sha512-OUSQNF7um7AvgPyBiK6ENfjqEG434oeVkRG97U8foLftOfcJfKcTi5pMtagJe5ytANPH5TlbfVgEokAl6RSj6g==",
+      "version": "14.2.1",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-14.2.1.tgz",
+      "integrity": "sha512-jLO8986l0/jW+K2Y5BHAhrD6ztnm8MHQgnTI5BwKV6can/LN6xYBcLbtUSvDt1jXNTASwCZszZk0ZBUT5YmH6Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.7",
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/prompts": "^8.7.0",
-        "@inquirer/type": "^4.1.0",
+        "@inquirer/ansi": "^2.0.8",
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/prompts": "^8.7.1",
+        "@inquirer/type": "4.1.1",
         "mute-stream": "^3.0.0",
         "run-async": "^4.0.6"
       },

--- a/examples/forge-sql-orm-example-simple/static/forge-orm-example/package-lock.json
+++ b/examples/forge-sql-orm-example-simple/static/forge-orm-example/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@atlaskit/css-reset": "^8.4.0",
-        "@atlaskit/dynamic-table": "^19.3.1",
+        "@atlaskit/dynamic-table": "^19.3.2",
         "@forge/bridge": "^6.3.1",
         "mobx": "7.0.3",
         "mobx-react": "10.0.2",
@@ -198,9 +198,9 @@
       }
     },
     "node_modules/@atlaskit/dynamic-table": {
-      "version": "19.3.1",
-      "resolved": "https://registry.npmjs.org/@atlaskit/dynamic-table/-/dynamic-table-19.3.1.tgz",
-      "integrity": "sha512-5XFmU7E3qnYekp/Vqebp1Jo+aPHor5s4ruVRI0nuWp67zW7Efm+S02WA46dy5fHf8fCedMdTWj1pn0ehEXcVwQ==",
+      "version": "19.3.2",
+      "resolved": "https://registry.npmjs.org/@atlaskit/dynamic-table/-/dynamic-table-19.3.2.tgz",
+      "integrity": "sha512-0y5E3pvVGYujJTIFIqaCd1pBnJd7ZUNPsSEvHJKf7CiD46kkDFo5n1F29z0DwIbC1MR6gd0x+XVB28Pxb/R2jw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@atlaskit/analytics-next": "^12.5.0",
@@ -218,8 +218,8 @@
         "@compiled/react": "^1.0.2"
       },
       "peerDependencies": {
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react": "^18.2.0 || ^19.0.0",
+        "react-dom": "^18.2.0 || ^19.0.0"
       }
     },
     "node_modules/@atlaskit/editor-prosemirror": {

--- a/examples/forge-sql-orm-example-simple/static/forge-orm-example/package.json
+++ b/examples/forge-sql-orm-example-simple/static/forge-orm-example/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "dependencies": {
     "@atlaskit/css-reset": "^8.4.0",
-    "@atlaskit/dynamic-table": "^19.3.1",
+    "@atlaskit/dynamic-table": "^19.3.2",
     "@forge/bridge": "^6.3.1",
     "mobx": "7.0.3",
     "mobx-react": "10.0.2",

--- a/examples/forge-sql-orm-example-sql-executor/package-lock.json
+++ b/examples/forge-sql-orm-example-sql-executor/package-lock.json
@@ -671,9 +671,9 @@
       }
     },
     "node_modules/@inquirer/ansi": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.7.tgz",
-      "integrity": "sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.8.tgz",
+      "integrity": "sha512-WpQM+Ti6Z40EFwwt+uL2p4UabT+W179zHp6HhLVOzfbwnVn05IPO/eXIZXGNqcT1jbQ15SujNLzQ39k4QPPxBQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -681,16 +681,16 @@
       }
     },
     "node_modules/@inquirer/checkbox": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.2.3.tgz",
-      "integrity": "sha512-XEYX2WA8SBkLPczL6/yXPHLPCvDoptmh9v56Cy05BSV1Smk1vWy19bTC4qJBuIffw7+6l4CcaYYzGqG60RfW1g==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.2.4.tgz",
+      "integrity": "sha512-oKT5RNeO9oKYizSyOxKb66IrKUsYVMQD2tnjllYW4wmSOe9WawfL3OE2p82JuvAyo+/nDIEem5P4Bm/ZIVYVew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.7",
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/figures": "^2.0.8",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/ansi": "^2.0.8",
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/figures": "^2.0.9",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -705,14 +705,14 @@
       }
     },
     "node_modules/@inquirer/confirm": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.3.0.tgz",
-      "integrity": "sha512-pZHXJImFtERmSNMBHcjwuz8Ck5vEFEYNUZnwbb8aJpjHv/TwGuFErNxF2Hp8+V+pNJs2EYPMlyWscvFEqO9jOQ==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.3.1.tgz",
+      "integrity": "sha512-HvnOHal39DTenOVoRpIy8Z+n4YYfNa3Qhi/P8zFqn9/d1crpmQG0DPx34rwOeOFvotgKr9Vov/14OmKR/Iwfjw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -727,15 +727,15 @@
       }
     },
     "node_modules/@inquirer/core": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-12.0.1.tgz",
-      "integrity": "sha512-JMD5Jy/ScL5TZE18m83Nw25HjqGFLoWXwnEkW7IdwwAhZpB9Bus55/WU7zn3UqR1MOCjjTQOIYpiD4vjWA3LPw==",
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-12.0.2.tgz",
+      "integrity": "sha512-9pBhkxE14uUlnHhs8lOt7qVPtS4caRY6CjADl8COejl9Mf7w8i6Uoe3DrljCqYtmYM3Iv2Q6EmPxx/oTYbvTAQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.7",
-        "@inquirer/figures": "^2.0.8",
-        "@inquirer/type": "^4.1.0",
+        "@inquirer/ansi": "^2.0.8",
+        "@inquirer/figures": "^2.0.9",
+        "@inquirer/type": "4.1.1",
         "cli-width": "^4.1.0",
         "fast-wrap-ansi": "^0.2.0",
         "mute-stream": "^3.0.0",
@@ -754,15 +754,15 @@
       }
     },
     "node_modules/@inquirer/editor": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.3.1.tgz",
-      "integrity": "sha512-y43COoyVUjPWIobn2Qep/uI1drPS78aaZZZ9kVi94Tyu/GuW2N8d8Q4rifJXGAXCEAXCPTTMjD8gC1HyvM5ukA==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.3.2.tgz",
+      "integrity": "sha512-7ruKO5d/wxhGHxdCQ3eyP/aBNrPTZ+Ju7ERtnAwuIsu0RSLs6kotlTRkOxHatbD6sDaEEdwsD82pzFiT9ESIyQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/external-editor": "^3.0.4",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/external-editor": "^3.0.5",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -777,14 +777,14 @@
       }
     },
     "node_modules/@inquirer/expand": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.1.3.tgz",
-      "integrity": "sha512-3NQJiXNJ/aj9wiAsr7pECdp5Qe9J0X9YUJCKsaFXS+ddOxfL6J4AIl3w3T4Gq3kK0WsQY5GMoDokK5X94m6lHw==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.1.4.tgz",
+      "integrity": "sha512-12o4aYnjWouoq0fyVhYIL+hwXAaga+kntA/wrijFmVvn2heinkdvkbEXRt1Ob/9IOJ285US5tntjfI/Ukt2YkA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -799,9 +799,9 @@
       }
     },
     "node_modules/@inquirer/external-editor": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-3.0.4.tgz",
-      "integrity": "sha512-tZbbaK2ovq6vlrRBNQvjrypmrED/p5x2ncIHQ79cD55tei3dD96v5glMMA+6tiq7K104i/25DVYKWVPJuV6ptA==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-3.0.5.tgz",
+      "integrity": "sha512-f3QQJRIX5ZEneBHNUIuPjmbdzHnmRFJA8r2dkcb8q+OM5Uv5KtnuAttQumnrjcBVBM3mcTX1CkmtAkU58VRZxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -838,9 +838,9 @@
       }
     },
     "node_modules/@inquirer/figures": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.8.tgz",
-      "integrity": "sha512-tApbon79GM9ry56ja/Ud3SY2CL4TQsao9fIwDQbgTeNY55025GdMzQ2+UdegV/lx51VNGUB59M0v0nMpybYY4Q==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.9.tgz",
+      "integrity": "sha512-EAWgUTGQ/Umgga51dE3B2PUHbufuXarDfg86uVgoSgNHNNQnyFKcOrQLWVqYMghuSyHh8+2HUH0Js9cTC1WAdg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -848,14 +848,14 @@
       }
     },
     "node_modules/@inquirer/input": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.1.4.tgz",
-      "integrity": "sha512-3xQkQrOvgOzpSN2ciTVdRDlg1FWMCA8l+0KfB6SNlILoTCGzJTzO/gc0Rwjcb3usuGyKdaGtI6OiyMdeMeLWkg==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.1.5.tgz",
+      "integrity": "sha512-2MkYYFD1Owt1eRBwHhsLSutysRodWasA4DVpl42KJKGmzwBTXRYAIXujisrt0UW0UohUlMjNjLfMDbw4emRbfw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -870,14 +870,14 @@
       }
     },
     "node_modules/@inquirer/number": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.2.1.tgz",
-      "integrity": "sha512-5KaqwZNLRpUuWcoCrYghPP9TMaXL5v2Sk4xqePM7RCVegcJStoXdWibio60YIC1bec+z1fCyb67N6XPJIkZtGA==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.2.2.tgz",
+      "integrity": "sha512-tjW1gMIQsFb/9Ie11i8SpuPARBdyCVfC5XOeVugWovrdm8CpjzN+A1CBX5QwCCN2mtNmpgDDCnuLCCT94cQ5zA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -892,15 +892,15 @@
       }
     },
     "node_modules/@inquirer/password": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.2.0.tgz",
-      "integrity": "sha512-CvVcW09emkBESEOW+4R8CjLNkP3fB3XrjeL8CDvfpjgrJN+V9oerXmJAXXM3l+4xqYPD5Yaujzy/Ph0PLOdDuA==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.2.1.tgz",
+      "integrity": "sha512-InA6nJxMCXPavPBiTKYHIsYiWz/mkIsk1rkI6pKp5w18gVawqrZOj7eSzSmPJa3j0pVxXm6RlrFP1BE9YeOixA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.7",
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/ansi": "^2.0.8",
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -915,22 +915,22 @@
       }
     },
     "node_modules/@inquirer/prompts": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.7.0.tgz",
-      "integrity": "sha512-yQwBMYvpJ6jqrXtKiOwRD5XezjJoyt3VQvIyjsr5Arqb519nfIohOQymWVJ8/vEgg8xtZerrCsqlSaqt/LPC9A==",
+      "version": "8.7.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.7.1.tgz",
+      "integrity": "sha512-xJIKWyrFNUKj3R5VEub/iKodG9Sh/MbCeApZUbATJgHTw8YoAJ2gOT78HlvO6NMFiRvjm6ySM7aiAew/zVY0Sw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/checkbox": "^5.2.3",
-        "@inquirer/confirm": "^6.3.0",
-        "@inquirer/editor": "^5.3.1",
-        "@inquirer/expand": "^5.1.3",
-        "@inquirer/input": "^5.1.4",
-        "@inquirer/number": "^4.2.1",
-        "@inquirer/password": "^5.2.0",
-        "@inquirer/rawlist": "^5.3.3",
-        "@inquirer/search": "^4.3.1",
-        "@inquirer/select": "^5.2.3"
+        "@inquirer/checkbox": "^5.2.4",
+        "@inquirer/confirm": "^6.3.1",
+        "@inquirer/editor": "^5.3.2",
+        "@inquirer/expand": "^5.1.4",
+        "@inquirer/input": "^5.1.5",
+        "@inquirer/number": "^4.2.2",
+        "@inquirer/password": "^5.2.1",
+        "@inquirer/rawlist": "^5.3.4",
+        "@inquirer/search": "^4.3.2",
+        "@inquirer/select": "^5.2.4"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -945,14 +945,14 @@
       }
     },
     "node_modules/@inquirer/rawlist": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.3.3.tgz",
-      "integrity": "sha512-Mu7WrtmDLaXBDEyrRLS70SZgX9ZSm4Up1w0ZxiH8C1OOp9oaVCn2k8q3QGgmlnhsKYUhuaU3zFWhAP6wxkVIMA==",
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.3.4.tgz",
+      "integrity": "sha512-c4fDwOpQsjJDHjXdHJE1/xXH6w9/BAiyu3QKzH9Ww5Xm1q37mzyUNa20L7qdtM1ECi4e+oUEKjhK8hR37OMAMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -967,15 +967,15 @@
       }
     },
     "node_modules/@inquirer/search": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.3.1.tgz",
-      "integrity": "sha512-0VWOvsHWI0rPj6CG70MoP4oXNCB6adcyN8bVFZXnh11eLDdPIK2f2XCmva78acPPDfJisfab7qNakwBh7hdBXw==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.3.2.tgz",
+      "integrity": "sha512-YIaEhWmfkdHEWOKwhF/oJar35FFTTrAdzNbJDo9lSsRT6E/obRPx9oVm4rkTMtlcJSqGYttNtLbcHQef9Qw2yw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/figures": "^2.0.8",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/figures": "^2.0.9",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -990,16 +990,16 @@
       }
     },
     "node_modules/@inquirer/select": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.2.3.tgz",
-      "integrity": "sha512-KuRTodDa6xBXX2noIpjuitpX/QT7Sfav7dIZ/OfUY54Hxg95nrGoshSzxx6Ey7qqLbImKdiGkSDt7KjPXjQgmA==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.2.4.tgz",
+      "integrity": "sha512-L9ubNaJdoBsiom/AfPKq0QLHTkhhCFCtszzdVidGremrlJjPZfGlmvp+IULKIbnYjtVFWnvb4mhiEdNTZ12ugA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.7",
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/figures": "^2.0.8",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/ansi": "^2.0.8",
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/figures": "^2.0.9",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -1014,9 +1014,9 @@
       }
     },
     "node_modules/@inquirer/type": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.1.0.tgz",
-      "integrity": "sha512-FMiJpuHUG3Dk0ex+UIXkre7i+i4OcwHWk9YdcVtZHFwb/r2rnrU2ipTCNAB7A+QOP0ryzIcqOfy76fRyyvOEAw==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.1.1.tgz",
+      "integrity": "sha512-yJoHYrMnxIsJZCY+0Vb66Dy3he3kL3e2wOBKhoSwWWAzZAY82emlxwgprCtp6yRixvNRNq9ztfRWQYPNr3Go7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2476,16 +2476,16 @@
       }
     },
     "node_modules/inquirer": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-14.2.0.tgz",
-      "integrity": "sha512-OUSQNF7um7AvgPyBiK6ENfjqEG434oeVkRG97U8foLftOfcJfKcTi5pMtagJe5ytANPH5TlbfVgEokAl6RSj6g==",
+      "version": "14.2.1",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-14.2.1.tgz",
+      "integrity": "sha512-jLO8986l0/jW+K2Y5BHAhrD6ztnm8MHQgnTI5BwKV6can/LN6xYBcLbtUSvDt1jXNTASwCZszZk0ZBUT5YmH6Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.7",
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/prompts": "^8.7.0",
-        "@inquirer/type": "^4.1.0",
+        "@inquirer/ansi": "^2.0.8",
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/prompts": "^8.7.1",
+        "@inquirer/type": "4.1.1",
         "mute-stream": "^3.0.0",
         "run-async": "^4.0.6"
       },

--- a/forge-sql-orm-cli/package-lock.json
+++ b/forge-sql-orm-cli/package-lock.json
@@ -14,7 +14,7 @@
         "drizzle-kit": "^0.31.10",
         "drizzle-orm": "^0.45.2",
         "forge-sql-orm": "^2.2.3",
-        "inquirer": "^14.2.0",
+        "inquirer": "^14.2.1",
         "mysql2": "^3.24.3",
         "reflect-metadata": "^0.2.2",
         "uuid": "^14.0.2"
@@ -896,24 +896,24 @@
       }
     },
     "node_modules/@inquirer/ansi": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.7.tgz",
-      "integrity": "sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.8.tgz",
+      "integrity": "sha512-WpQM+Ti6Z40EFwwt+uL2p4UabT+W179zHp6HhLVOzfbwnVn05IPO/eXIZXGNqcT1jbQ15SujNLzQ39k4QPPxBQ==",
       "license": "MIT",
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
       }
     },
     "node_modules/@inquirer/checkbox": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.2.3.tgz",
-      "integrity": "sha512-XEYX2WA8SBkLPczL6/yXPHLPCvDoptmh9v56Cy05BSV1Smk1vWy19bTC4qJBuIffw7+6l4CcaYYzGqG60RfW1g==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.2.4.tgz",
+      "integrity": "sha512-oKT5RNeO9oKYizSyOxKb66IrKUsYVMQD2tnjllYW4wmSOe9WawfL3OE2p82JuvAyo+/nDIEem5P4Bm/ZIVYVew==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.7",
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/figures": "^2.0.8",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/ansi": "^2.0.8",
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/figures": "^2.0.9",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -928,13 +928,13 @@
       }
     },
     "node_modules/@inquirer/confirm": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.3.0.tgz",
-      "integrity": "sha512-pZHXJImFtERmSNMBHcjwuz8Ck5vEFEYNUZnwbb8aJpjHv/TwGuFErNxF2Hp8+V+pNJs2EYPMlyWscvFEqO9jOQ==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.3.1.tgz",
+      "integrity": "sha512-HvnOHal39DTenOVoRpIy8Z+n4YYfNa3Qhi/P8zFqn9/d1crpmQG0DPx34rwOeOFvotgKr9Vov/14OmKR/Iwfjw==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -949,14 +949,14 @@
       }
     },
     "node_modules/@inquirer/core": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-12.0.1.tgz",
-      "integrity": "sha512-JMD5Jy/ScL5TZE18m83Nw25HjqGFLoWXwnEkW7IdwwAhZpB9Bus55/WU7zn3UqR1MOCjjTQOIYpiD4vjWA3LPw==",
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-12.0.2.tgz",
+      "integrity": "sha512-9pBhkxE14uUlnHhs8lOt7qVPtS4caRY6CjADl8COejl9Mf7w8i6Uoe3DrljCqYtmYM3Iv2Q6EmPxx/oTYbvTAQ==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.7",
-        "@inquirer/figures": "^2.0.8",
-        "@inquirer/type": "^4.1.0",
+        "@inquirer/ansi": "^2.0.8",
+        "@inquirer/figures": "^2.0.9",
+        "@inquirer/type": "4.1.1",
         "cli-width": "^4.1.0",
         "fast-wrap-ansi": "^0.2.0",
         "mute-stream": "^3.0.0",
@@ -975,14 +975,14 @@
       }
     },
     "node_modules/@inquirer/editor": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.3.1.tgz",
-      "integrity": "sha512-y43COoyVUjPWIobn2Qep/uI1drPS78aaZZZ9kVi94Tyu/GuW2N8d8Q4rifJXGAXCEAXCPTTMjD8gC1HyvM5ukA==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.3.2.tgz",
+      "integrity": "sha512-7ruKO5d/wxhGHxdCQ3eyP/aBNrPTZ+Ju7ERtnAwuIsu0RSLs6kotlTRkOxHatbD6sDaEEdwsD82pzFiT9ESIyQ==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/external-editor": "^3.0.4",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/external-editor": "^3.0.5",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -997,13 +997,13 @@
       }
     },
     "node_modules/@inquirer/expand": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.1.3.tgz",
-      "integrity": "sha512-3NQJiXNJ/aj9wiAsr7pECdp5Qe9J0X9YUJCKsaFXS+ddOxfL6J4AIl3w3T4Gq3kK0WsQY5GMoDokK5X94m6lHw==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.1.4.tgz",
+      "integrity": "sha512-12o4aYnjWouoq0fyVhYIL+hwXAaga+kntA/wrijFmVvn2heinkdvkbEXRt1Ob/9IOJ285US5tntjfI/Ukt2YkA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -1018,9 +1018,9 @@
       }
     },
     "node_modules/@inquirer/external-editor": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-3.0.4.tgz",
-      "integrity": "sha512-tZbbaK2ovq6vlrRBNQvjrypmrED/p5x2ncIHQ79cD55tei3dD96v5glMMA+6tiq7K104i/25DVYKWVPJuV6ptA==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-3.0.5.tgz",
+      "integrity": "sha512-f3QQJRIX5ZEneBHNUIuPjmbdzHnmRFJA8r2dkcb8q+OM5Uv5KtnuAttQumnrjcBVBM3mcTX1CkmtAkU58VRZxg==",
       "license": "MIT",
       "dependencies": {
         "chardet": "^2.1.1",
@@ -1055,22 +1055,22 @@
       }
     },
     "node_modules/@inquirer/figures": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.8.tgz",
-      "integrity": "sha512-tApbon79GM9ry56ja/Ud3SY2CL4TQsao9fIwDQbgTeNY55025GdMzQ2+UdegV/lx51VNGUB59M0v0nMpybYY4Q==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.9.tgz",
+      "integrity": "sha512-EAWgUTGQ/Umgga51dE3B2PUHbufuXarDfg86uVgoSgNHNNQnyFKcOrQLWVqYMghuSyHh8+2HUH0Js9cTC1WAdg==",
       "license": "MIT",
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
       }
     },
     "node_modules/@inquirer/input": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.1.4.tgz",
-      "integrity": "sha512-3xQkQrOvgOzpSN2ciTVdRDlg1FWMCA8l+0KfB6SNlILoTCGzJTzO/gc0Rwjcb3usuGyKdaGtI6OiyMdeMeLWkg==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.1.5.tgz",
+      "integrity": "sha512-2MkYYFD1Owt1eRBwHhsLSutysRodWasA4DVpl42KJKGmzwBTXRYAIXujisrt0UW0UohUlMjNjLfMDbw4emRbfw==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -1085,13 +1085,13 @@
       }
     },
     "node_modules/@inquirer/number": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.2.1.tgz",
-      "integrity": "sha512-5KaqwZNLRpUuWcoCrYghPP9TMaXL5v2Sk4xqePM7RCVegcJStoXdWibio60YIC1bec+z1fCyb67N6XPJIkZtGA==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.2.2.tgz",
+      "integrity": "sha512-tjW1gMIQsFb/9Ie11i8SpuPARBdyCVfC5XOeVugWovrdm8CpjzN+A1CBX5QwCCN2mtNmpgDDCnuLCCT94cQ5zA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -1106,14 +1106,14 @@
       }
     },
     "node_modules/@inquirer/password": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.2.0.tgz",
-      "integrity": "sha512-CvVcW09emkBESEOW+4R8CjLNkP3fB3XrjeL8CDvfpjgrJN+V9oerXmJAXXM3l+4xqYPD5Yaujzy/Ph0PLOdDuA==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.2.1.tgz",
+      "integrity": "sha512-InA6nJxMCXPavPBiTKYHIsYiWz/mkIsk1rkI6pKp5w18gVawqrZOj7eSzSmPJa3j0pVxXm6RlrFP1BE9YeOixA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.7",
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/ansi": "^2.0.8",
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -1128,21 +1128,21 @@
       }
     },
     "node_modules/@inquirer/prompts": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.7.0.tgz",
-      "integrity": "sha512-yQwBMYvpJ6jqrXtKiOwRD5XezjJoyt3VQvIyjsr5Arqb519nfIohOQymWVJ8/vEgg8xtZerrCsqlSaqt/LPC9A==",
+      "version": "8.7.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.7.1.tgz",
+      "integrity": "sha512-xJIKWyrFNUKj3R5VEub/iKodG9Sh/MbCeApZUbATJgHTw8YoAJ2gOT78HlvO6NMFiRvjm6ySM7aiAew/zVY0Sw==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/checkbox": "^5.2.3",
-        "@inquirer/confirm": "^6.3.0",
-        "@inquirer/editor": "^5.3.1",
-        "@inquirer/expand": "^5.1.3",
-        "@inquirer/input": "^5.1.4",
-        "@inquirer/number": "^4.2.1",
-        "@inquirer/password": "^5.2.0",
-        "@inquirer/rawlist": "^5.3.3",
-        "@inquirer/search": "^4.3.1",
-        "@inquirer/select": "^5.2.3"
+        "@inquirer/checkbox": "^5.2.4",
+        "@inquirer/confirm": "^6.3.1",
+        "@inquirer/editor": "^5.3.2",
+        "@inquirer/expand": "^5.1.4",
+        "@inquirer/input": "^5.1.5",
+        "@inquirer/number": "^4.2.2",
+        "@inquirer/password": "^5.2.1",
+        "@inquirer/rawlist": "^5.3.4",
+        "@inquirer/search": "^4.3.2",
+        "@inquirer/select": "^5.2.4"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -1157,13 +1157,13 @@
       }
     },
     "node_modules/@inquirer/rawlist": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.3.3.tgz",
-      "integrity": "sha512-Mu7WrtmDLaXBDEyrRLS70SZgX9ZSm4Up1w0ZxiH8C1OOp9oaVCn2k8q3QGgmlnhsKYUhuaU3zFWhAP6wxkVIMA==",
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.3.4.tgz",
+      "integrity": "sha512-c4fDwOpQsjJDHjXdHJE1/xXH6w9/BAiyu3QKzH9Ww5Xm1q37mzyUNa20L7qdtM1ECi4e+oUEKjhK8hR37OMAMQ==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -1178,14 +1178,14 @@
       }
     },
     "node_modules/@inquirer/search": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.3.1.tgz",
-      "integrity": "sha512-0VWOvsHWI0rPj6CG70MoP4oXNCB6adcyN8bVFZXnh11eLDdPIK2f2XCmva78acPPDfJisfab7qNakwBh7hdBXw==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.3.2.tgz",
+      "integrity": "sha512-YIaEhWmfkdHEWOKwhF/oJar35FFTTrAdzNbJDo9lSsRT6E/obRPx9oVm4rkTMtlcJSqGYttNtLbcHQef9Qw2yw==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/figures": "^2.0.8",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/figures": "^2.0.9",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -1200,15 +1200,15 @@
       }
     },
     "node_modules/@inquirer/select": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.2.3.tgz",
-      "integrity": "sha512-KuRTodDa6xBXX2noIpjuitpX/QT7Sfav7dIZ/OfUY54Hxg95nrGoshSzxx6Ey7qqLbImKdiGkSDt7KjPXjQgmA==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.2.4.tgz",
+      "integrity": "sha512-L9ubNaJdoBsiom/AfPKq0QLHTkhhCFCtszzdVidGremrlJjPZfGlmvp+IULKIbnYjtVFWnvb4mhiEdNTZ12ugA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.7",
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/figures": "^2.0.8",
-        "@inquirer/type": "^4.1.0"
+        "@inquirer/ansi": "^2.0.8",
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/figures": "^2.0.9",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -1223,9 +1223,9 @@
       }
     },
     "node_modules/@inquirer/type": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.1.0.tgz",
-      "integrity": "sha512-FMiJpuHUG3Dk0ex+UIXkre7i+i4OcwHWk9YdcVtZHFwb/r2rnrU2ipTCNAB7A+QOP0ryzIcqOfy76fRyyvOEAw==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.1.1.tgz",
+      "integrity": "sha512-yJoHYrMnxIsJZCY+0Vb66Dy3he3kL3e2wOBKhoSwWWAzZAY82emlxwgprCtp6yRixvNRNq9ztfRWQYPNr3Go7A==",
       "license": "MIT",
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -3904,15 +3904,15 @@
       }
     },
     "node_modules/inquirer": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-14.2.0.tgz",
-      "integrity": "sha512-OUSQNF7um7AvgPyBiK6ENfjqEG434oeVkRG97U8foLftOfcJfKcTi5pMtagJe5ytANPH5TlbfVgEokAl6RSj6g==",
+      "version": "14.2.1",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-14.2.1.tgz",
+      "integrity": "sha512-jLO8986l0/jW+K2Y5BHAhrD6ztnm8MHQgnTI5BwKV6can/LN6xYBcLbtUSvDt1jXNTASwCZszZk0ZBUT5YmH6Q==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.7",
-        "@inquirer/core": "^12.0.1",
-        "@inquirer/prompts": "^8.7.0",
-        "@inquirer/type": "^4.1.0",
+        "@inquirer/ansi": "^2.0.8",
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/prompts": "^8.7.1",
+        "@inquirer/type": "4.1.1",
         "mute-stream": "^3.0.0",
         "run-async": "^4.0.6"
       },

--- a/forge-sql-orm-cli/package.json
+++ b/forge-sql-orm-cli/package.json
@@ -50,7 +50,7 @@
     "drizzle-kit": "^0.31.10",
     "drizzle-orm": "^0.45.2",
     "forge-sql-orm": "^2.2.3",
-    "inquirer": "^14.2.0",
+    "inquirer": "^14.2.1",
     "mysql2": "^3.24.3",
     "reflect-metadata": "^0.2.2",
     "uuid": "^14.0.2"

--- a/forge-sql-orm-extra/package-lock.json
+++ b/forge-sql-orm-extra/package-lock.json
@@ -4318,9 +4318,9 @@
       }
     },
     "node_modules/socks": {
-      "version": "2.8.9",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
-      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+      "version": "2.8.10",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.10.tgz",
+      "integrity": "sha512-e0VyvkVTwVYViNovRkZ9aodhxVlyoMn7eJhVUPxZ+eK9P/7CBkxvvsBOHqFPEH416726W8tLXXXjKwqgTErrCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5911,9 +5911,9 @@
       }
     },
     "node_modules/socks": {
-      "version": "2.8.9",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
-      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+      "version": "2.8.10",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.10.tgz",
+      "integrity": "sha512-e0VyvkVTwVYViNovRkZ9aodhxVlyoMn7eJhVUPxZ+eK9P/7CBkxvvsBOHqFPEH416726W8tLXXXjKwqgTErrCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Automated dependency update produced by `.github/workflows/autoupdate.yml`. Will auto-merge once required checks pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the table display component used across SQL ORM examples.
  - Updated the command-line interface’s interactive prompt dependency.
  - These updates include the latest patch-level improvements and fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->